### PR TITLE
Add empty entries for dark themes, and a few maybe-missed dark&light ones

### DIFF
--- a/Themes - Alternative Checkboxes.md
+++ b/Themes - Alternative Checkboxes.md
@@ -140,1225 +140,1391 @@ Themes are ordered from most popular to least popular at the time of writing.
 ---
 
 # Minimal
+['dark', 'light']
 Repo: https://github.com/kepano/obsidian-minimal
-Docs: https://minimal.guide/checklists
-Code: https://github.com/kepano/obsidian-minimal/blob/master/src/scss/features/checklist-icons.scss
-
-- [ ] To-Do `- [ ]`
-- [/] Incomplete `- [/]`
-- [x] Done `- [x]`
-- [-] Cancelled `- [-]`
-- [>] Forwarded `- [>]`
-- [<] Scheduling `- [<]`
-
-- [?] Question `- [?]`
-- [!] Important `- [!]`
-- [*] Star `- [*]`
-- ["] Quote `- ["]`
-- [l] Location `- [l]`
-- [b] Bookmark `- [b]`
-- [i] Information `- [i]`
-- [S] Savings `- [S]`
-- [I] Idea `- [I]`
-- [p] Pros `- [p]`
-- [c] Cons `- [c]`
-- [f] Fire `- [f]`
-- [k] Key `- [k]`
-- [w] Win `- [w]`
-- [u] Up `- [u]`
-- [d] Down `- [d]`
+Docs: 
+Code: 
 
 ---
 
 # Things
+['light', 'dark']
 Repo: https://github.com/colineckert/obsidian-things
-Docs: https://github.com/colineckert/obsidian-things?tab=readme-ov-file#checkbox-styling
-Code: https://github.com/colineckert/obsidian-things/blob/9d0a8b44007a335ee829a0d3843ab579051eeb70/theme.css#L661
-
-- [ ] To-Do `- [ ]`
-- [/] Incomplete `- [/]`
-- [x] Done `- [x]`
-- [-] Cancelled `- [-]`
-- [>] Forwarded `- [>]`
-- [<] Scheduling `- [<]`
-
-- [?] Question `- [?]`
-- [!] Important `- [!]`
-- [*] Star `- [*]`
-- ["] Quote `- ["]`
-- [l] Location `- [l]`
-- [b] Bookmark `- [b]`
-- [i] Information `- [i]`
-- [S] Savings `- [S]`
-- [I] Idea `- [I]`
-- [p] Pros `- [p]`
-- [c] Cons `- [c]`
-- [f] Fire `- [f]`
-- [k] Key `- [k]`
-- [w] Win `- [w]`
-- [u] Up `- [u]`
-- [d] Down `- [d]`
-
-- [D] Draft Pull Request `- [D]`
-- [P] Open Pull Request `- [P]`
-- [M] Merged Pull Request `- [M]`
+Docs: 
+Code: 
 
 ---
 
 # Blue Topaz
-Repo: https://github.com/PKM-er/Blue-Topaz_Obsidian-css
-Docs: https://github.com/PKM-er/Blue-topaz-example/blob/96ecdaa485f0b4e4b8c22c7fea4394be1b882c83/Demo%20Note.md?plain=1#L144
-Code:
-- https://github.com/PKM-er/Blue-Topaz_Obsidian-css/blob/d55ba0b88ee2d91b49bd5cce66039685c27073f4/theme.css#L11739
-- https://github.com/PKM-er/Blue-Topaz_Obsidian-css/blob/d55ba0b88ee2d91b49bd5cce66039685c27073f4/theme.css#L29306
-
-- [>] Rescheduled `- [>]`
-- [<] Scheduled `- [<]`
-- [!] Important `- [!]`
-- [-] Cancelled `- [-]`
-- [/] In Progress `- [/]`
-
-- ["] Quote`- ["]`
-- [?] Question `- [?]`
-- [*] Star `- [*]`
-- [n] Note `- [n]`
-- [l] Location `- [l]`
-- [i] Information `- [i]`
-- [I] Idea / Light bulb `- [I]`
-- [S] Amount `- [S]`
-- [p] Pro `- [p]`
-- [c] Con `- [c]`
-- [b] Bookmark `- [b]`
-- [f] Fire `- [f]`
-- [w] Win `- [w]`
-- [k] Key `- [k]`
-- [u] Up `- [u]`
-- [d] Down `- [d]`
-- [F] Feature `- [F]`
-- [r] Rule / Law `- [r]`
-- [m] Measurement `- [m]`
-- [M] Medical `- [M]`
-- [L] Translate / Language `- [L]`
-- [t] Clock / Time `- [t]`
-- [T] Telephone `- [T]`
-- [P] Person `- [P]`
-- [#] Tags `- [#]`
-- [W] World `- [W]`
-- [U] Universe `- [U]`
+['dark', 'light']
+Repo: https://github.com/whyt-byte/Blue-Topaz_Obsidian-css
+Docs: 
+Code: 
 
 ---
 
 # AnuPpuccin
-
+['dark', 'light']
 Repo: https://github.com/AnubisNekhet/AnuPpuccin
-Docs: https://github.com/AnubisNekhet/AnuPpuccin?tab=readme-ov-file#custom-checkboxes--speech-bubbles
-Code: https://github.com/AnubisNekhet/AnuPpuccin/blob/main/src/modules/Features/custom-checkboxes.scss
+Docs: 
+Code: 
 
-Style Settings Required: `AnuPpuccin -> File Editor & Markdown Elements -> Checkboxes -> Enable Custom Checkboxes`
+---
 
-- [ ] Unchecked `- [ ]`
-- [x] Checked `- [x]`
-- [>] Rescheduled `- [>]`
-- [<] Scheduled `- [<]`
-- [!] Important `- [!]`
-- [-] Cancelled `- [-]`
-- [/] In Progress `- [/]`
-- [?] Question `- [?]`
-- [*] Star `- [*]`
-- [n] Note `- [n]`
-- [l] Location `- [l]`
-- [i] Information `- [i]`
-- [I] Idea `- [I]`
-- [S] Amount `- [S]`
-- [p] Pro `- [p]`
-- [c] Con `- [c]`
-- [b] Bookmark `- [b]`
-- ["] Quote `- ["]`
-- [u] Up `- [u]`
-- [d] Down `- [d]`
-- [w] Win `- [w]`
-- [k] Key `- [k]`
-- [f] Fire `- [f]`
-- [0] Speech bubble 0 `- [0]`
-- [1] Speech bubble 1 `- [1]`
-- [2] Speech bubble 2 `- [2]`
-- [3] Speech bubble 3 `- [3]`
-- [4] Speech bubble 4 `- [4]`
-- [5] Speech bubble 5 `- [5]`
-- [6] Speech bubble 6 `- [6]`
-- [7] Speech bubble 7 `- [7]`
-- [8] Speech bubble 8 `- [8]`
-- [9] Speech bubble 9 `- [9]`
+# Obsidianite
+['dark']
+Repo: https://github.com/bennyxguo/Obsidian-Obsidianite
+Docs: 
+Code: 
 
 ---
 
 # Sanctum
+['dark', 'light']
 Repo: https://github.com/jdanielmourao/obsidian-sanctum
-Docs: https://github.com/jdanielmourao/obsidian-sanctum/blob/main/documentation/Theme_Guide.md
-Code: https://github.com/jdanielmourao/obsidian-sanctum/blob/main/src/scss/features/custom-checkboxes.scss
-
-- [i] Information `- [i]`
-- [-] Cancelled `- [-]`
-- [<] Scheduled `- [<]`
-- [>] Rescheduled/Forwarded `- [>]`
-- [?] Question `- [?]`
-- [!] Important `- [!]`
-- [l] Location `- [l]`
-- [x] Task `- [x]`
-- [ ] Task `- [ ]`
-- [I] Idea `- [I]`
-- [p] Thumbs up `- [p]`
-- [c] Thumbs down `- [c]`
-- [S] Piggy bank `- [S]`
-- [s] Money `- [s]`
-- [a] Bell `- [a]`
-- [b] Bookmark `- [b]`
-- [n] Pin `- [n]`
-- [B] Bug `- [B]`
-- [W] Reward `- [W]`
+Docs: 
+Code: 
 
 ---
 
 # ITS Theme
+['dark', 'light']
 Repo: https://github.com/SlRvb/Obsidian--ITS-Theme
-Docs: https://publish.obsidian.md/slrvb-docs/ITS+Theme/Alternate+Checkboxes
-Code: https://github.com/SlRvb/Obsidian--ITS-Theme/blob/main/SCSS/Alternate%20Checkboxes.scss
+Docs: 
+Code: 
 
-- [ ] Unchecked `- [ ]`
-- [x] Regular `- [x]`
-- [X] Checked  `- [X]`
-- [-] Dropped  `- [-]`
-- [>] Forward  `- [>]`
-- [<] Migrated  `- [<]`
-- [D] Date  `- [D]`
-- [?] Question  `- [?]`
-- [/] Half Done  `- [/]`
-- [+] Add  `- [+]`
-- [R] Research  `- [R]`
-- [!] Important  `- [!]`
-- [i] Idea  `- [i]`
-- [B] Brainstorm  `- [B]`
-- [P] Pro  `- [P]`
-- [C] Con  `- [C]`
-- [Q] Quote  `- [Q]`
-- [N] Note  `- [N]`
-- [b] Bookmark  `- [b]`
-- [I] Information  `- [I]`
-- [p] Paraphrase  `- [p]`
-- [L] Location  `- [L]`
-- [E] Example  `- [E]`
-- [A] Answer  `- [A]`
-- [r] Reward `- [r]`
-- [c] Choice  `- [c]`
-- [d] Doing  `- [d]`
-- [T] Time  `- [T]`
-- [@] Character / Person  `- [@]`
-- [t] Talk  `- [t]`
-- [O] Outline / Plot  `- [O]`
-- [~] Conflict  `- [~]`
-- [W] World  `- [W]`
-- [f] Clue / Find  `- [f]`
-- [F] Foreshadow  `- [F]`
-- [H] Favorite / Health  `- [H]`
-- [&] Symbolism  `- [&]`
-- [s] Secret  `- [s]`
+---
+
+# Dracula for Obsidian
+['dark']
+Repo: https://github.com/jarodise/Dracula-for-Obsidian.md
+Docs: 
+Code: 
+
+---
+
+# Everforest
+['dark', 'light']
+Repo: https://github.com/mrglitchbyte/obsidian_everforest
+Docs: 
+Code: 
+
+---
+
+# Cybertron
+['dark']
+Repo: https://github.com/nickmilo/Cybertron
+Docs: 
+Code: 
 
 ---
 
 # Primary
-
+['light', 'dark']
 Repo: https://github.com/primary-theme/obsidian
-Docs: https://primary-theme.github.io/features/checkboxes/#checklists
-Code: https://github.com/primary-theme/obsidian/blob/main/src/scss/40_editor/_alt-checkboxes.scss
-
-- [/] In Progress `- [/]`
-- [>] Rescheduled `- [>]`
-- [<] Scheduled `- [<]`
-- [!] Important `- [!]`
-- [-] Cancelled `- [-]`
-- [?] Question `- [?]`
-- [*] Star `- [*]`
-- [n] Note `- [n]`
-- [l] Location `- [l]`
-- [i] Information `- [i]`
-- [S] Amount `- [S]`
-- ["] Quote `- ["]`
-- [I] Idea `- [I]`
-- [p] Pro `- [p]`
-- [c] Con `- [c]`
-- [b] Bookmark  `- [b]`
-- [u] Up `- [u]`
-- [d] Down `- [d]`
-- [r] Rule/Law  `- [r]`
-- [L] Language/Translation  `- [L]`
-- [t] Time/Clock `- [t]`
-- [T] Telephone `- [T]`
+Docs: 
+Code: 
 
 ---
 
 # Tokyo Night
-
+['dark', 'light']
 Repo: https://github.com/tcmmichaelb139/obsidian-tokyonight
-Docs: None (Appears to have used ones from Border theme)
-Code: https://github.com/tcmmichaelb139/obsidian-tokyonight/blob/ea79aba4359704497be7e40d15628636c81a9a0d/theme.css#L562
+Docs: 
+Code: 
 
-- [ ] To Do `- [ ]`
-- [/] In Progress `- [/]`
-- [x] Done `- [x]`
-- [-] Cancelled `- [-]`
-- [>] Rescheduled `- [>]`
-- [<] Scheduling `- [<]`
+---
 
-- [!] Important `- [!]`
-- [?] Question `- [?]`
-- [i] Information `- [i]`
-- [S] Amount `- [S]`
-- [*] Star `- [*]`
-- [b] Bookmark `- [b]`
-- ["] Quote `- ["]`
-- [l] Location `- [l]`
-- [I] Idea `- [I]`
-- [p] Pros `- [p]`
-- [c] Cons `- [c]`
-- [u] Up `- [u]`
-- [d] Down `- [d]`
-
-- [n] Note `- [n]`
+# Yin and Yang
+['dark', 'light']
+Repo: https://github.com/chetachiezikeuzor/Yin-and-Yang-Theme
+Docs: 
+Code: 
 
 ---
 
 # Border
-
+['dark', 'light']
 Repo: https://github.com/Akifyss/obsidian-border
-Docs: https://github.com/Akifyss/obsidian-border?tab=readme-ov-file#alternate-checkboxes
-Code: https://github.com/Akifyss/obsidian-border/blob/2771957ab92e6faddd7edad4e0cf65b7e8ef66bb/theme.css#L7844
-
-- [ ] To Do `- [ ]`
-- [/] In Progress `- [/]`
-- [x] Done `- [x]`
-- [-] Cancelled `- [-]`
-- [>] Rescheduled `- [>]`
-- [<] Scheduling `- [<]`
-
-- [!] Important `- [!]`
-- [?] Question `- [?]`
-- [i] Information `- [i]`
-- [S] Amount `- [S]`
-- [*] Star `- [*]`
-- [b] Bookmark `- [b]`
-- ["] Quote `- ["]`
-- [l] Location `- [l]`
-- [I] Idea `- [I]`
-- [p] Pros `- [p]`
-- [c] Cons `- [c]`
-- [u] Up `- [u]`
-- [d] Down `- [d]`
-
-- [n] Note `- [n]`
+Docs: 
+Code: 
 
 ---
 
-# Spectrum (Unmaintained Pre-1.0 Release)
+# Obuntu
+['dark', 'light']
+Repo: https://github.com/DubininDmitry/Obuntu-theme-for-Obsidian
+Docs: 
+Code: 
 
-Repo: https://github.com/wiktoriavh/Spectrum
-Docs: https://github.com/wiktoriavh/Spectrum/wiki/Different-Task-Checkboxes
-Code: https://github.com/wiktoriavh/Spectrum/blob/6c24513a3af57a7ebaeff63df7e62bf47513efac/SCSS/_blocks/_listings/_task-list.scss#L63
+---
 
-- [>] Forward `- [>]`
-- [+] Plus `- [+]`
-- [-] Minus `- [-]`
-- [!] Exclamation `- [!]`
-- [?] Question `- [?]`
-- [x] Normal `- [x]`
+# Terminal
+['dark']
+Repo: https://github.com/zcysxy/Obsidian-Terminal-Theme
+Docs: 
+Code: 
+
+---
+
+# Dracula Official
+['dark']
+Repo: https://github.com/dracula/obsidian
+Docs: 
+Code: 
+
+---
+
+# Spectrum
+['dark', 'light']
+Repo: https://github.com/Braweria/Spectrum
+Docs: 
+Code: 
 
 ---
 
 # Cyber Glow
+['dark', 'light']
 Repo: https://github.com/ArtexJay/Obsidian-CyberGlow
-Docs: https://github.com/ArtexJay/Obsidian-CyberGlow?tab=readme-ov-file#what-to-expect
-Code: https://github.com/ArtexJay/Obsidian-CyberGlow/blob/main/theme.css#L3436
+Docs: 
+Code: 
 
+---
 
-- [x] Checkmark `- [x]`
-- [?] Question `- [?]`
-- [-] Removed `- [-]`
-- [!] Important  `- [!]`
-- [>] Delayed `- [>]`
-- [/] Half-done/WIP  `- [/]`
-- [R] Review  `- [R]`
-- [+] Archived `- [+]`
-- [b] Bookmark  `- [b]`
-- [B] Brainstorm `- [B]`
-- [D] Planned `- [D]`
-- [i] Idea `- [i]`
-- [I] Info `- [I]`
-- [N] Note `- [N]`
-- [<] Scheduling `- [<]`
-- [P] Positive  `- [P]` or `- [p]`
-- [C] Negative  `- [C]` or `- [c]`
-- [Q] Quote `- [Q]` or `- ["]`
-- [S] Savings `- [S]`
-- [f] Fire `- [f]`
-- [k] Key `- [k]`
-- [w] Win `- [w]`
-- [u] Up `- [u]`
-- [d] Down `- [d]`
-- [l] Location `- [l]`
-- [*] Star `- [*]`
+# LYT Mode
+['dark']
+Repo: https://github.com/nickmilo/LYT-Mode
+Docs: 
+Code: 
 
 ---
 
 # Shiba Inu
-
+['dark', 'light']
 Repo: https://github.com/faroukx/Obsidian-shiba-inu-theme
-Docs: https://github.com/faroukx/Obsidian-shiba-inu-theme?tab=readme-ov-file#personalized-checkboxes
-Code: https://github.com/faroukx/Obsidian-shiba-inu-theme/blob/main/theme.css (Only minified available)
-
-- [ ] Unchecked `- [ ]`
-- [x] Checked `- [x]`
-- [>] Rescheduled `- [>]`
-- [<] Scheduled `- [<]`
-- [!] Important `- [!]`
-- [-] Cancelled `- [-]`
-- [/] In Progress `- [/]`
-- [?] Question `- [?]`
-- [*] Star `- [*]`
-- [n] Note `- [n]`
-- [l] Location `- [l]`
-- [i] Information `- [i]`
-- [I] Idea `- [I]`
-- [S] Amount `- [S]`
-- [p] Pro `- [p]`
-- [c] Con `- [c]`
-- [b] Bookmark `- [b]`
-- [s] Study `- [s]`
-- [r] Reminder `- [r]`
+Docs: 
+Code: 
 
 ---
 
-# PLN (Pipe Loves Nord)
-
+# PLN
+['dark', 'light']
 Repo: https://github.com/PipeItToDevNull/PLN
-Docs: https://github.com/PipeItToDevNull/PLN?tab=readme-ov-file#custom-checkboxes
-Code: https://github.com/PipeItToDevNull/PLN/blob/master/snippets/checkboxes.css
+Docs: 
+Code: 
 
-- [ ] Open `- [ ]`
-- [x] Complete `- [x]`
-- [!] Important `- [!]`
-- [>] Deferred `- [>]`
-- [?] Question `- [?]`
-- [i] Info `- [i]`
-- [-] Cancelled  `- [-]`
-- [/] Partial `- [/]`
+---
+
+# Dark Moss
+['dark']
+Repo: https://github.com/sergey900553/obsidian_githublike_theme
+Docs: 
+Code: 
+
+---
+
+# Discordian
+['dark']
+Repo: https://github.com/radekkozak/discordian
+Docs: 
+Code: 
+
+---
+
+# Sodalite
+['dark']
+Repo: https://github.com/tomzorz/Sodalite
+Docs: 
+Code: 
 
 ---
 
 # Obsidianotion
-
+['dark', 'light']
 Repo: https://github.com/diegoeis/obsidianotion
-Docs: https://github.com/diegoeis/obsidianotion?tab=readme-ov-file#checklists-styles
-Code: https://github.com/diegoeis/obsidianotion/blob/092b29b9aaece2d5a0975ffe4d6b4c75b62e44fd/theme.css#L1221
+Docs: 
+Code: 
 
-Uses the same set as Things / Minimal themes.
+---
 
-- [ ] Normal `- [ ]`
-- [/] Incomplete `- [/]`
-- [x] Done `- [x]`
-- [-] Cancelled `- [-]`
-- [>] Forwarded `- [>]`
-- [<] Scheduling `- [<]`
+# Bubble Space
+['dark', 'light']
+Repo: https://github.com/Emrie-Candera/Bubble-Space-Theme
+Docs: 
+Code: 
 
-- [?] Question `- [?]`
-- [!] Exclamation `- [!]`
-- [*] Star `- [*]`
-- ["] Quote `- ["]`
-- [l] Location `- [l]`
-- [b] Bookmark `- [b]`
-- [i] Information `- [i]`
-- [S] Savings `- [S]`
-- [I] Idea `- [I]`
-- [p] Thumbs Up `- [p]`
-- [c] Thumbs Down `- [c]`
-- [f] Fire `- [f]`
-- [k] Key `- [k]`
-- [w] Win `- [w]`
-- [u] Up `- [u]`
-- [d] Down `- [d]`
+---
 
-- [s] Thread? / String?  `- [s]` (Specified incorrectly in Docs as Forwarded but available with no label in code)
+# Gitsidian
+['dark', 'light']
+Repo: https://github.com/ishgunacar/gitsidian
+Docs: 
+Code: 
+
+---
+
+# Blackbird
+['dark']
+Repo: https://github.com/vanadium23/obsidian-blackbird-theme
+Docs: 
+Code: 
 
 ---
 
 # Maple
-
+['dark', 'light']
 Repo: https://github.com/subframe7536/obsidian-theme-maple
-Docs:
-Code: https://github.com/subframe7536/obsidian-theme-maple/blob/bb117504f9fe91e804442f175d9a94f67bb8dbf0/src/editor/checkbox.scss
-
-Uses code from Border theme.
-
-- [ ] To Do `- [ ]`
-- [/] In Progress `- [/]`
-- [x] Done `- [x]`
-- [-] Cancelled `- [-]`
-- [>] Rescheduled `- [>]`
-- [<] Scheduling `- [<]`
-
-- [!] Important `- [!]`
-- [?] Question `- [?]`
-- [i] Information `- [i]`
-- [S] Amount `- [S]`
-- [*] Star `- [*]`
-- [b] Bookmark `- [b]`
-- ["] Quote `- ["]`
-- [l] Location `- [l]`
-- [I] Idea `- [I]`
-- [p] Pros `- [p]`
-- [c] Cons `- [c]`
-- [u] Up `- [u]`
-- [d] Down `- [d]`
-
-- [n] Note `- [n]` 
+Docs: 
+Code: 
 
 ---
 
-# EbullientWorks
+# Ebullientworks
+['dark', 'light']
 Repo: https://github.com/ebullient/obsidian-theme-ebullientworks
-Docs: https://github.com/ebullient/obsidian-theme-ebullientworks?tab=readme-ov-file#alternative-checkboxes
-Code: https://github.com/ebullient/obsidian-theme-ebullientworks/blob/main/src/fragments/_06a-checkbox-mixin.scss
-
-- [ ] Unchecked `- [ ]`
-- [x] Checked `- [x]`
-- [-] Cancelled `- [-]`
-- [/] In Progress `- [/]`
-- [>] Deferred `- [>]`
-- [!] Important `- [!]`
-- [?] Question `- [?]`
-- [r] Review `- [r]` or `- [R]` (Capital R - Not mentioned in docs)
-- [b] Bookmark `- [b]` (Not mentioned in docs)
+Docs: 
+Code: 
 
 ---
 
-# Forest Pine Berry (Unmaintained?)
-Repo: https://github.com/Nilahn/pine_forest_berry/
-Docs: None (Appears to use Minimal snippet)
-Code: https://github.com/Nilahn/pine_forest_berry/blob/e74bd849e654c22b857229ef0f9c6c6834090d2a/obsidian.css#L999
+# Ars Magna
+['dark', 'light']
+Repo: https://github.com/mediapathic/obsidian-arsmagna-theme
+Docs: 
+Code: 
 
-Doesn't install correctly since it only has `obsidian.css` and no `theme.css`.
+---
 
-- [>] Forwarded `- [>]`
-- [<] Schedule `- [<]`
-- [?] Question `- [?]`
-- [/] Incomplete `- [/]`
-- [!] Important `- [!]`
-- ["] Quote `- ["]`
-- [-] Cancelled `- [-]`
-- [*] Star `- [*]`
-- [l] Location `- [l]`
-- [i] Info `- [i]`
-- [S] Amount / Savings / Money `- [S]`
-- [I] Idea / Light Bulb `- [I]`
-- [f] Fire `- [f]`
-- [k] Key `- [k]`
-- [u] Up `- [u]`
-- [d] Down `- [d]`
-- [w] Win  `- [w]`
-- [p] Pros `- [p]`
-- [c] Cons  `- [c]`
-- [b] Bookmark `- [b]`
+# Pine Forest Berry
+['dark', 'light']
+Repo: https://github.com/Nilahn/pine_forest_berry
+Docs: 
+Code: 
 
 ---
 
 # Aura
-
+['dark', 'light']
 Repo: https://github.com/ashwinjadhav818/obsidian-aura
-Docs: None (I guessed the uses based on other implementations)
-Code: https://github.com/ashwinjadhav818/obsidian-aura/blob/925571586651e756bf38632178cc4a387f5a6c98/src/features/checkbox.scss
+Docs: 
+Code: 
 
-- [x] Check `- [x]`
-- [X] Alt Check? `- [X]`
-- [?] Question `- [?]`
-- [-] Cancelled? `- [-]`
-- [!] Important  `- [!]`
-- [>] Deffered?  `- [>]`
-- [/] Settings? `- [/]`
-- [R] Clock / Time `- [R]`
-- [+] Add? `- [+]`
-- [b] Bookmark `- [b]`
-- [B] Bolt?  `- [B]`
-- [D] Date / Callendar ? `- [D]`
-- [I] Information `- [I]`
-- [i] Idea / Light Bulb `- [i]`
-- [N] Note `- [N]`
-- [Q] Quote `- [Q]`
-- [P] Thumbs Up `- [P]`
-- [C] Thumbs Down `- [C]`
+---
+
+# Dracula + LYT
+['dark']
+Repo: https://github.com/xRyul/ObsidianMD_Dracula_x_LYT
+Docs: 
+Code: 
+
+---
+
+# Pisum
+['dark']
+Repo: https://github.com/GuangluWu/obsidian-pisum
+Docs: 
+Code: 
+
+---
+
+# Comfort color dark
+['dark']
+Repo: https://github.com/obsidian-ezs/obsidian-comfort-color-dark
+Docs: 
+Code: 
+
+---
+
+# Nebula
+['dark']
+Repo: https://github.com/dlccyes/obsidian-nebula
+Docs: 
+Code: 
+
+---
+
+# Harmonic
+['dark', 'light']
+Repo: https://github.com/Thiews/Obsidian-Harmonic
+Docs: 
+Code: 
+
+---
+
+# Vanilla AMOLED
+['dark']
+Repo: https://github.com/SakuraIsayeki/vanilla-amoled-theme
+Docs: 
+Code: 
+
+---
+
+# Dawn
+['dark', 'light']
+Repo: https://github.com/minheeyoon/Dawn
+Docs: 
+Code: 
+
+---
+
+# Firefly
+['dark']
+Repo: https://github.com/lazercaveman/obsidian-firefly-theme
+Docs: 
+Code: 
+
+---
+
+# Comfort Smooth
+['dark']
+Repo: https://github.com/sparklau/comfort-smooth
+Docs: 
+Code: 
+
+---
+
+# Faded
+['dark']
+Repo: https://github.com/JoshKasap/Obsidian-Faded-Theme
+Docs: 
+Code: 
+
+---
+
+# Mammoth
+['dark']
+Repo: https://github.com/Wittionary/mammoth-obsidian-theme
+Docs: 
+Code: 
 
 ---
 
 # Vicious
-
+['light', 'dark']
 Repo: https://github.com/zaheralmajed/vicious-theme-obsidian
-Docs: https://github.com/zaheralmajed/vicious-theme-obsidian?tab=readme-ov-file#enhanced-checkboxes
-Code: https://github.com/zaheralmajed/vicious-theme-obsidian/blob/686d487e0705fd6b7aced4451400512bba919f56/theme.css#L2547
-
-- [ ] Unchecked `- [ ]`
-- [x] Checked `- [x]`
-- [-] Cancelled `- [-]`
-- [)] Good `- [)]`
-- [:] Pin `- [:]`
-- [(] Bad `- [(]`
-- [}] High `- [}]`
-- [=] Normal `- [=]`
-- [{] Low `- [{]`
-- [?] Question `- [?]`
-- [*] Star `- [*]`
-- [!] Important `- [!]`
-- [>] Forward `- [>]`
-- [<] Backward `- [<]`
-- [/] Pause `- [/]`
-- [+] Upward `- [+]`
-- [_] Downward `- [_]`
-- [%] Recurring `- [%]`
-- [&] Trash `- [&]`
-- [.] Lock `- [.]`
-- [@] At `- [@]`
-- [#] Hashtag `- [#]`
-- ['] Quote `- [']`
-- [a] Archive `- [a]`
-- [A] Alarm  `- [A]`
-- [b] Bookmark `- [b]`
-- [B] Birthday `- [B]`
-- [c] Comment `- [c]`
-- [C] Clip `- [C]`
-- [d] Diamond `- [d]`
-- [D] Document `- [D]`
-- [e] Envelope `- [e]`
-- [E] Eye `- [E]`
-- [f] Flame `- [f]`
-- [F] Financial `- [F]`
-- [g] Gaming `- [g]`
-- [G] GYM `- [G]`
-- [h] Home `- [h]`
-- [H] Heart `- [H]`
-- [i] Info `- [i]`
-- [I] Idea `- [I]`
-- [m] Music `- [m]`
-- [M] Medical `- [M]`
-- [p] Person `- [p]`
-- [P] Plane `- [P]`
-- [s] Sport `- [s]`
-- [S] Search `- [S]`
-- [u] URL `- [u]`
-- [v] Video `- [v]`
-- [w] World `- [w]`
-- [W] Work `- [W]`
-- [z] Moon `- [z]`
-- [Z] Sun `- [Z]`
-- [0] Text Highlight 0 `- [0]`
-- [1] Text Highlight 1 `- [1]`
-- [2] Text Highlight 2 `- [2]`
-- [3] Text Highlight 3 `- [3]`
-- [4] Text Highlight 4 `- [4]`
-- [5] Text Highlight 5 `- [5]`
-- [6] Text Highlight 6 `- [6]`
-- [7] Text Highlight 7 `- [7]`
-- [8] Text Highlight 8 `- [8]`
-- [9] Text Highlight 9 `- [9]`
-- [§] Text Highlight § `- [§]`
-
----
-
-# Elegance
-
-Repo: https://github.com/Victologo/elegance-theme
-Docs: https://github.com/Victologo/elegance-theme?tab=readme-ov-file#checboxes-minimal-theme-by-kepano
-Code: https://github.com/Victologo/elegance-theme/blob/83947941e3f44fb4f37df291c8cff08f299cc2fc/theme.css#L3644
-
-- [ ] To-Do `- [ ]`
-- [/] Incomplete `- [/]` (Not mentioned in Docs)
-- [x] Done `- [x]`
-- [-] Cancelled `- [-]`
-- [>] Forwarded `- [>]`
-- [<] Scheduling `- [<]`
-
-- [?] Question `- [?]`
-- [!] Important `- [!]`
-- [*] Star `- [*]`
-- ["] Quote `- ["]`
-- [l] Location `- [l]`
-- [b] Bookmark `- [b]`
-- [i] Information `- [i]`
-- [S] Savings `- [S]`
-- [I] Idea `- [I]`
-- [p] Pros `- [p]`
-- [c] Cons `- [c]`
-- [f] Fire `- [f]`
-- [k] Key `- [k]`
-- [w] Win `- [w]`
-- [u] Up `- [u]`
-- [d] Down `- [d]`
+Docs: 
+Code: 
 
 ---
 
 # Simple
+['dark', 'light']
 Repo: https://github.com/diegoeis/simple-obsidian
-Docs: https://github.com/diegoeis/simple-obsidian?tab=readme-ov-file#checklists-styles
-Code: https://github.com/diegoeis/simple-obsidian/blob/2b45f172c7c0840dcf94d173ddf89b2a1ba53aa0/theme.css#L733
+Docs: 
+Code: 
 
-Uses the same set as Things / Minimal themes.
+---
 
-- [ ] To-Do `- [ ]`
-- [/] Incomplete `- [/]`
-- [x] Done `- [x]`
-- [-] Cancelled `- [-]`
-- [>] Forwarded `- [>]`
-- [<] Scheduling `- [<]`
+# Elegance
+['dark', 'light']
+Repo: https://github.com/Victologo/elegance-theme
+Docs: 
+Code: 
 
-- [?] Question `- [?]`
-- [!] Important `- [!]`
-- [*] Star `- [*]`
-- ["] Quote `- ["]`
-- [l] Location `- [l]`
-- [b] Bookmark `- [b]`
-- [i] Information `- [i]`
-- [S] Savings `- [S]`
-- [I] Idea `- [I]`
-- [p] Pros `- [p]`
-- [c] Cons `- [c]`
-- [f] Fire `- [f]`
-- [k] Key `- [k]`
-- [w] Win `- [w]`
-- [u] Up `- [u]`
-- [d] Down `- [d]`
+---
+
+# Aurora
+['dark']
+Repo: https://github.com/auroral-ui/aurora-obsidian-md
+Docs: 
+Code: 
+
+---
+
+# Material Ocean
+['dark']
+Repo: https://github.com/dragonwocky/obsidian-material-ocean
+Docs: 
+Code: 
+
+---
+
+# Hipstersmoothie
+['dark']
+Repo: https://github.com/hipstersmoothie/hipstersmoothie-obsidian-theme
+Docs: 
+Code: 
+
+---
+
+# Obsidian Windows 98 Edition
+['dark', 'light']
+Repo: https://github.com/SMUsamaShah/Obsidian-Win98-Edition
+Docs: 
+Code: 
+
+---
+
+# Behave dark
+['dark']
+Repo: https://github.com/Chrismettal/Obsidian-Behave-dark
+Docs: 
+Code: 
 
 ---
 
 # Sparkling Night
+['dark', 'light']
 Repo: https://github.com/isax785/obsidian-sparkling-night
-Docs: https://github.com/isax785/obsidian-sparkling-night
-Code: https://github.com/isax785/obsidian-sparkling-night/blob/e7436b653c0c287a5f8a3c246d8a301107a4edfa/theme.css#L256
+Docs: 
+Code: 
 
-Only works in Live Preview.
+---
 
-- [>] Working Progress `- [>]`
-- [-] Pause / Stand-By `- [-]`
-- [/] Stop `- [/]`
-- [<] To Be Scheduled `- [<]`
+# Purple Aurora
+['dark']
+Repo: https://github.com/AndreasStandar/Obsidian-Theme---Purple-Aurora
+Docs: 
+Code: 
 
 ---
 
 # Kakano
-
+['dark', 'light']
 Repo: https://github.com/isaacfreeman/kakano-obsidian-theme
-Docs: https://github.com/isaacfreeman/kakano-obsidian-theme?tab=readme-ov-file#selected-alternate-checkboxes
-Code: https://github.com/isaacfreeman/kakano-obsidian-theme/blob/2e4e869043eca019839ef8b6b774196edb81211b/theme.css#L2082
+Docs: 
+Code: 
 
-"Idea borrowed from Minimal theme"
+---
 
-- [/] Partially `- [/]`
-- [<] Scheduling `- [<]`
-- [-] Cancelled `- [-]`
-- [>] Forwarded `- [>]`
-- [!] Important `- [!]`
-- [?] Question `- [?]`
+# Rosé Pine Moon
+['dark']
+Repo: https://github.com/mimishahzad/rose-pine-moon-obsidian
+Docs: 
+Code: 
+
+---
+
+# deeper work
+['dark']
+Repo: https://github.com/lucas-fern/obsidian-deeper-work-theme
+Docs: 
+Code: 
 
 ---
 
 # Neo
+['dark', 'light']
 Repo: https://github.com/lab-do/obsidian-neo
-Docs: https://github.com/lab-do/obsidian-neo?tab=readme-ov-file#alternate-checkboxes
-Code: https://github.com/lab-do/obsidian-neo/blob/0955f59136e498461a2de78655eef42cbcf66606/theme.css#L999
-
-- [ ] Checkbox `- [ ]`
-- [x] Complete `- [x]`
-- [/] Incomplete `- [/]`
-- [-] Cancelled `- [-]`
-- [>] Forwarded `- [>]`
-- [<] Schedule `- [<]`
-
-- [i] Info `- [i]`
-- [I] Idea `- [I]`
-- [!] Important `- [!]`
-- [?] Question `- [?]`
-- [p] Pros `- [p]`
-- [c] Cons `- [c]`
-
-- [f] Fire `- [f]`
-- [*] Star `- [*]`
-- [b] Bookmark `- [b]`
-- [u] Trend Up `- [u]`
-- [d] Trend Down `- [d]`
-- [w] Win `- [w]`
-
-- [k] Key `- [k]`
-- ["] Quote `- ["]`
-- [S] Money `- [S]`
-- [l] Location `- [l]`
-- [n] New `- [n]`
-
-- [0] Progress 0 `- [0]`
-- [1] Progress 1 `- [1]`
-- [2] Progress 2 `- [2]`
-- [3] Progress 3 `- [3]`
-- [4] Progress 4 `- [4]`
+Docs: 
+Code: 
 
 ---
 
 # Feather
-Repo: https://github.com/zfmohammed/obsidian-feather
-Docs: https://github.com/zfmohammed/obsidian-feather?tab=readme-ov-file#themes (Screenshots)
-Code: https://github.com/zfmohammed/obsidian-feather/blob/da83afd4dd10ba387a7eee59c00f0b8e022d3748/theme.css#L162
+['dark', 'light']
+Repo: https://github.com/MFdev-coder/obsidian-feather
+Docs: 
+Code: 
 
-Mentions using Things Theme for Checkboxes.
+---
 
-- [ ] To-Do `- [ ]`
-- [/] Incomplete `- [/]`
-- [x] Done `- [x]`
-- [-] Cancelled `- [-]`
-- [>] Forwarded `- [>]`
-- [<] Scheduling `- [<]`
+# Theme-That-Shall-Not-Be-Named
+['dark']
+Repo: https://github.com/ChopTV/Obsidian-Theme-That-Shall-Not-Be-Named
+Docs: 
+Code: 
 
-- [?] Question `- [?]`
-- [!] Important `- [!]`
-- [*] Star `- [*]`
-- ["] Quote `- ["]`
-- [l] Location `- [l]`
-- [b] Bookmark `- [b]`
-- [i] Information `- [i]`
-- [S] Savings `- [S]`
-- [I] Idea `- [I]`
-- [p] Pros `- [p]`
-- [c] Cons `- [c]`
-- [f] Fire `- [f]`
-- [k] Key `- [k]`
-- [w] Win `- [w]`
-- [u] Up `- [u]`
-- [d] Down `- [d]`
+---
 
-- [D] Draft Pull Request `- [D]`
-- [P] Open Pull Request `- [P]`
-- [M] Merged Pull Request `- [M]`
+# Darkyan
+['dark']
+Repo: https://github.com/johackim/obsidian-darkyan
+Docs: 
+Code: 
+
+---
+
+# Dracula Gemini
+['dark']
+Repo: https://github.com/clbn/dracula-gemini
+Docs: 
+Code: 
+
+---
+
+# Obsdn-Dark-Rmx
+['dark', 'light']
+Repo: https://github.com/cannibalox/Obsdn-dark-rmx
+Docs: 
+Code: 
+
+---
+
+# Hulk
+['dark']
+Repo: https://github.com/pgalliford/Obsidian-theme-Incredible-Hulk
+Docs: 
+Code: 
 
 ---
 
 # Listive
+['dark', 'light']
 Repo: https://github.com/efemkay/obsidian-listive-theme
-Docs: https://github.com/efemkay/obsidian-listive-theme?tab=readme-ov-file#list-related-features (Mentions taking Checkboxes from Border Theme)
-Code: https://github.com/efemkay/obsidian-listive-theme/blob/698f27ce12d23ee451712639df9c4b429019f751/theme.css#L1070
-
-- [/] Partial / Incomplete `- [/]`
-- [>] Defer / Reschedule `- [>]`
-- [-] Cancelled `- [-]`
-- [<] Schedule / Meeting `- [<]`
-- [I] Idea / Light Bulb `- [I]`
-- [i] Info `- [i]`
-- [!] Warning `- [!]`
-- ["] Citation, my version `- ["]`
-- [r] Reference `- [r]`
-- [*] Star / Favourites `- [*]`
+Docs: 
+Code: 
 
 ---
 
 # MagicUser
+['dark', 'light']
 Repo: https://github.com/drbap/magicuser-theme-for-obsidian
-Docs: https://github.com/drbap/magicuser-theme-for-obsidian?tab=readme-ov-file#custom-checkbox-icons
-Code: https://github.com/drbap/magicuser-theme-for-obsidian/blob/33ebb74f4355cd4a46725415ea328ad9781ad46e/theme.css#L1382
+Docs: 
+Code: 
 
-- [ ] Unchecked `- [ ]`
-- [x] Checked `- [x]`
-- [-] Cancelled `- [-]`
+---
 
-- [/] Work in Progress `- [/]`
-- [g] Results / Graphics / Stats `- [g]`
+# AbsoluteGruv
+['dark']
+Repo: https://github.com/kkYrusobad/AbsoluteGruv
+Docs: 
+Code: 
 
-- [!] Important `- [!]`
-- [?] Question  `- [?]`
-- [i] Information `- [i]`
-- [I] Idea `- [I]`
+---
 
-- [<] Date - Scheduled `- [<]`
-- [>] Date - Rescheduled `- [>]`
-- [e] Email `- [e]`
-- [t] Time `- [t]`
-- [f] Phone `- [f]`
-- [F] Flight `- [F]`
+# ion
+['dark']
+Repo: https://github.com/zamsyt/obsidian-ion
+Docs: 
+Code: 
 
-- [l] Location `- [l]`
-- [b] Bookmark `- [b]`
-- [q] Quote `- [q]` or `- ["]`
+---
 
-- [p] Pro `- [p]`
-- [c] Con `- [c]`
+# Amethyst
+['dark', 'light']
+Repo: https://github.com/cotemaxime/obsidian-amethyst
+Docs: 
+Code: 
 
-- [1] Arrow Up - Increase `- [1]`
-- [2] Arrow Down - Decrease `- [2]`
-- [3] Arrow Right `- [3]`
+---
 
-- [s] Star `- [s]` or `- [*]`
-- [S] Price / Money `- [S]`
-- [n] Note `- [n]`
+# Purple Owl
+['dark']
+Repo: https://github.com/zacharyc/purple-owl-theme
+Docs: 
+Code: 
 
-- [m] Magic Wand `- [m]`
+---
 
-**Extra 1**
-- [k] Key `- [k]`
-- [w] Win `- [w]`
-- [u] Up `- [u]`
-- [d] Down `- [d]`
+# Violet Evening
+['dark']
+Repo: https://github.com/aitaDev/Violet-Evening-for-Obsidian
+Docs: 
+Code: 
 
-- [D] Draft Pull Request `- [D]`
-- [P] Open Pull Request `- [P]`
-- [M] Merged Pull Request  `- [M]`
+---
 
-**Extra 2**
-- [B] Branch `- [B]`
-- [T] Test `- [T]`
+# Dracula Slim
+['dark']
+Repo: https://github.com/bLaCkwEw/Dracula-Slim
+Docs: 
+Code: 
 
-- [o] Issue `- [o]`
-- [O] Closed Issue `- [O]`
+---
 
-- [U] User `- [U]`
-- [W] Password `- [W]`
-- [C] Cart / Buy `- [C]`
-- [a] Add / Plus `- [a]`
-- [r] Remove / Minus  `- [r]`
+# Ayu Mirage
+['dark']
+Repo: https://github.com/bcdavasconcelos/Obsidian-Ayu_Mirage
+Docs: 
+Code: 
 
-**Extra 3**
-- [G] Group / Users `- [G]`
+---
 
-- [R] Reference / Repository `- [R]`
-- [E] Eye / View `- [E]`
-- [A] Activity `- [A]`
-- [L] Lesson / Presentation `- [L]`
+# Apatheia
+['dark']
+Repo: https://github.com/AmadeusWM/Obsidian-Apatheia
+Docs: 
+Code: 
 
-- [h] Home `- [h]`
-- [H] Health / Fitness `- [H]`
+---
 
-- [Q] Quality `- [Q]`
+# Everblush
+['dark']
+Repo: https://github.com/Everblush/Obsidian
+Docs: 
+Code: 
+
+---
+
+# Traffic Lights
+['dark', 'light']
+Repo: https://github.com/elliotboyd/obsidian-traffic-lights
+Docs: 
+Code: 
+
+---
+
+# Dark Graphite
+['dark']
+Repo: https://github.com/bcdavasconcelos/Obsidian-Graphite
+Docs: 
+Code: 
+
+---
+
+# Zenburn
+['dark']
+Repo: https://github.com/danyim/obsidian-zenburn
+Docs: 
+Code: 
+
+---
+
+# Micro Mike
+['dark']
+Repo: https://github.com/ThisTheThe/MicroMike
+Docs: 
+Code: 
+
+---
+
+# monochroYOU
+['dark', 'light']
+Repo: https://github.com/GuiMar10/monochroYOU
+Docs: 
+Code: 
+
+---
+
+# Panic Mode
+['dark']
+Repo: https://github.com/bcdavasconcelos/Obsidian-Panic_Mode
+Docs: 
+Code: 
+
+---
+
+# Creature
+['dark']
+Repo: https://github.com/marcusolsson/obsidian-creature-theme
+Docs: 
+Code: 
+
+---
+
+# Emerald
+['dark']
+Repo: https://github.com/gracejoseph1236/obsidian-emerald
+Docs: 
+Code: 
+
+---
+
+# Charcoal
+['dark']
+Repo: https://github.com/bcdavasconcelos/Obsidian-Charcoal
+Docs: 
+Code: 
+
+---
+
+# halcyon
+['dark']
+Repo: https://github.com/dbarenholz/halcyon-obsidian
+Docs: 
+Code: 
+
+---
+
+# Base2Tone
+['dark']
+Repo: https://github.com/deathau/Base2Tone-For-Obsidian.md
+Docs: 
+Code: 
+
+---
+
+# ProtocolBlue
+['dark']
+Repo: https://github.com/PrettyBoyCosmo/ProtocolBlue
+Docs: 
+Code: 
+
+---
+
+# Dekurai
+['dark']
+Repo: https://github.com/sergey900553/obsidian_dekurai_theme
+Docs: 
+Code: 
 
 ---
 
 # Qlean
+['dark', 'light']
 Repo: https://github.com/Fro-Q/Qlean
-Docs: https://github.com/Fro-Q/Qlean/blob/main/assets/checkbox_style.png
-Code: https://github.com/Fro-Q/Qlean/blob/619efd313553e6cb6ce7a8c12cc05cf080e8e8df/theme.css#L672
+Docs: 
+Code: 
 
-- [ ] Unchecked `- [ ]`
-- [x] Checked `- [x]`
-- [-] Cancelled? `- [-]`
-- [?] Question? `- [?]`
-- [!] Important? `- [!]`
-- [i] Information? `- [i]`
+---
+
+# Ruby
+['dark']
+Repo: https://github.com/gracejoseph1236/obsidian-ruby
+Docs: 
+Code: 
+
+---
+
+# GitHubDHC
+['dark']
+Repo: https://github.com/ScottKirvan/GitHubDHC
+Docs: 
+Code: 
 
 ---
 
 # Yue
-Repo:https://github.com/GixoXYZ/YueObsidian
-Docs: https://github.com/GixoXYZ/YueObsidian?tab=readme-ov-file#checkbox-styling
-Code: https://github.com/GixoXYZ/YueObsidian/blob/fb138cf9b31396b20110c32082a76bd5d6cd8d1d/theme.css#L634
+['light', 'dark']
+Repo: https://github.com/thegixo/YueObsidian
+Docs: 
+Code: 
 
-Same as Minimal.
+---
 
-- [ ] To-Do `- [ ]`
-- [/] Incomplete `- [/]`
-- [x] Done `- [x]`
-- [-] Cancelled `- [-]`
-- [>] Forwarded `- [>]`
-- [<] Scheduling `- [<]`
+# Higlighter
+['light']
+Repo: https://github.com/lukauskas/obsidian-highlighter-theme
+Docs: 
+Code: 
 
-- [?] Question `- [?]`
-- [!] Important `- [!]`
-- [*] Star `- [*]`
-- ["] Quote `- ["]`
-- [l] Location `- [l]`
-- [b] Bookmark `- [b]`
-- [i] Information `- [i]`
-- [S] Savings `- [S]`
-- [I] Idea `- [I]`
-- [p] Pros `- [p]`
-- [c] Cons `- [c]`
-- [f] Fire `- [f]`
-- [k] Key `- [k]`
-- [w] Win `- [w]`
-- [u] Up `- [u]`
-- [d] Down `- [d]`
+---
+
+# Rmaki
+['dark']
+Repo: https://github.com/luke-rmaki/rmaki-obsidian
+Docs: 
+Code: 
+
+---
+
+# Nightfox
+['dark', 'light']
+Repo: https://github.com/mbromell/obsidian-nightfox
+Docs: 
+Code: 
 
 ---
 
 # sQdthOne
+['dark', 'light']
 Repo: https://github.com/KeithLerner/ObsidianMDsQdthOne
-Docs: None
-Code: https://raw.githubusercontent.com/KeithLerner/ObsidianMDsQdthOne/refs/heads/main/theme.css
+Docs: 
+Code: 
 
-- [>] Forwarded `- [>]`
-- [<] Schedule `- [<]`
-- [u] Up `- [u]`
-- [d] Down `- [d]`
-- [/] Incomplete `- [/]`
-- [?] Question `- [?]`
-- [!] Important `- [!]`
-- [i] Info `- [i]`
-- [*] Star `- [*]`
-- [+] Added `- [+]`
-- [-] Cancelled `- [-]`
-- [p] Pros `- [p]`
-- [c] Cons `- [c]`
-- [b] Bookmark `- [b]`
-- [l] Location `- [l]`
-- [s] Smile :) `- [s]`
-- [k] Key `- [k]`
-- [f] Fire `- [f]`
+---
+
+# Lizardmen Zettelkasten
+['light']
+Repo: https://github.com/dogwaddle/lizardmen-zettelkasten
+Docs: 
+Code: 
+
+---
+
+# SynthWave
+['dark']
+Repo: https://github.com/marcoluzi/obsidian-synthwave
+Docs: 
+Code: 
+
+---
+
+# Cybertron Shifted
+['dark']
+Repo: https://github.com/JorgEdmundo/cybertron-shifted
+Docs: 
+Code: 
+
+---
+
+# Iceberg
+['dark']
+Repo: https://github.com/izumin5210/obsidian-iceberg
+Docs: 
+Code: 
+
+---
+
+# WilcoxOne
+['dark']
+Repo: https://github.com/MattWilcox/obsidian-wilcox-one
+Docs: 
+Code: 
+
+---
+
+# Tokyo Night Storm
+['dark']
+Repo: https://github.com/arozx/obsidian_tokyo-night-storm
+Docs: 
+Code: 
+
+---
+
+# Dracula Plus
+['dark']
+Repo: https://github.com/saket61195/Dracula_obsidian_theme
+Docs: 
+Code: 
+
+---
+
+# Gastown
+['light']
+Repo: https://github.com/dogwaddle/obsidian-gastown-theme.md
+Docs: 
+Code: 
+
+---
+
+# Lemons Theme
+['dark']
+Repo: https://github.com/mProjectsCode/obsidian-lemons-theme
+Docs: 
+Code: 
+
+---
+
+# Novadust
+['dark']
+Repo: https://github.com/mmartamg/novadust-obsidian
+Docs: 
+Code: 
+
+---
+
+# Wombat
+['dark']
+Repo: https://github.com/hush-hush/obsidian_wombat
+Docs: 
+Code: 
+
+---
+
+# GDCT Dark
+['dark']
+Repo: https://github.com/bcdavasconcelos/Obsidian-GDCT_Dark
+Docs: 
+Code: 
+
+---
+
+# Synthwave '84
+['dark']
+Repo: https://github.com/G2Jose/synthwave-84-obsidian-theme
+Docs: 
+Code: 
+
+---
+
+# Viridian
+['dark', 'light']
+Repo: https://github.com/mulfok/obsidian-viridian
+Docs: 
+Code: 
+
+---
+
+# Ayu
+['light']
+Repo: https://github.com/bcdavasconcelos/Obsidian-Ayu
+Docs: 
+Code: 
+
+---
+
+# Solitude
+['dark']
+Repo: https://github.com/MajorEnkidu/solitude-obsidian-theme
+Docs: 
+Code: 
+
+---
+
+# Carpe Noctem
+['dark']
+Repo: https://github.com/operator-axel/obsdian_theme--Carpe_Noctem
+Docs: 
+Code: 
+
+---
+
+# Carnelian
+['dark']
+Repo: https://github.com/gracejoseph1236/obsidian-carnelian
+Docs: 
+Code: 
+
+---
+
+# Comfort Dark
+['dark']
+Repo: https://github.com/Ooopz/obsidianmd-theme-comfort-dark
+Docs: 
+Code: 
+
+---
+
+# Aura Dark
+['dark']
+Repo: https://github.com/Possibly-Matt/obsidian-aura-theme
+Docs: 
+Code: 
 
 ---
 
 # Prime
+['dark', 'light']
 Repo: https://github.com/rivea0/obsidian-prime
-Docs: https://github.com/rivea0/obsidian-prime?tab=readme-ov-file#custom-checkbox-styling
-Code: https://github.com/rivea0/obsidian-prime/blob/main/theme.css#L1774
-
-Uses the same set as Minimal theme and some from Things theme.
-
-- [ ] to do `- [ ]`
-- [/] incomplete `- [/]`
-- [x] done `- [x]`
-- [-] cancelled `- [-]`
-- [>] forwarded `- [>]`
-- [<] scheduling `- [<]`
-
-- [?] question `- [?]`
-- [!] important `- [!]`
-- [*] star `- [*]`
-- ["] quote `- ["]`
-- [l] location `- [l]`
-- [b] bookmark `- [b]`
-- [i] information `- [i]`
-- [S] savings `- [S]`
-- [I] idea `- [I]`
-- [p] pros `- [p]`
-- [c] cons `- [c]`
-- [f] fire `- [f]`
-- [k] key `- [k]`
-- [w] win `- [w]`
-- [u] up `- [u]`
-- [d] down `- [d]`
-- [D] draft pull request `- [D]`
-- [P] open pull request `- [P]`
-- [M] merged pull request `- [M]`
-
-- [m] mail `- [m]`
-- [h] heart `- [h]`
-- [a] archive `- [a]`
-- [e] eye `- [e]`
-- [s] search `- [s]`
-- [r] rocket `- [r]`
-- [8] infinity `- [8]`
-- [g] goal `- [g]`
-- [+] positive `- [+]`
-- [n] negative `- [n]`
+Docs: 
+Code: 
 
 ---
 
-# Sanctum Reborn
-Repo: https://github.com/antoKeinanen/obsidian-sanctum-reborn
-Docs: https://github.com/antoKeinanen/obsidian-sanctum-reborn/blob/main/documentation/Theme_Guide.md#features
-Code: https://github.com/antoKeinanen/obsidian-sanctum-reborn/blob/main/src/scss/features/custom-checkboxes.scss
+# Carbon
+['dark', 'light']
+Repo: https://github.com/vhbelvadi/obsidian-carbon
+Docs: 
+Code: 
 
-- [*] Star `- [*]`
-- [a] Reminder `- [a]`
-- [f] Favorite `- [f]`
-- [S] Savings `- [S]`
-- [-] Cancelled `- [-]`
-- [>] Rescheduled `- [>]`
-- [<] Scheduled `- [<]`
-- [l] Location `- [l]`
-- [B] Bug `- [B]`
-- [X] Failure `- [X]`
-- [n] Annotation `- [n]`
-- [p] Pros `- [p]`
-- [c] Cons `- [c]`
-- [w] Win `- [w]`
-- [b] Bookmark `- [b]`
-- [I] Idea `- [I]`
-- [!] Warning `- [!]`
-- [?] Question `- [?]`
-- [i] Info `- [i]`
-- [/] In Progress `- [/]`
-- [u] Trend Up `- [u]`
-- [d] Trend Down `- [d]`
-- [F] Feature `- [F]`
-- [r] Law `- [r]`
-- [m] Measurement `- [m]`
-- [M] Medical `- [M]`
-- [L] Language `- [L]`
-- [t] Time `- [t]`
-- [T] Call `- [T]`
-- [P] Person `- [P]`
-- [s] Money `- [s]`
+---
+
+# Modern Dark
+['dark']
+Repo: https://github.com/roberts-code/obsidian-theme-modern-dark
+Docs: 
+Code: 
+
+---
+
+# Atomus
+['dark']
+Repo: https://github.com/PedroHenrique17/Atomus
+Docs: 
+Code: 
+
+---
+
+# Sanctum reborn
+['dark', 'light']
+Repo: https://github.com/antoKeinanen/obsidian-sanctum-reborn
+Docs: 
+Code: 
+
+---
+
+# Rezin
+['dark']
+Repo: https://github.com/NicolasGHS/Rezin-theme
+Docs: 
+Code: 
+
+---
+
+# Tomorrow Night Bright
+['dark']
+Repo: https://github.com/gbraad/obsidian-tomorrow-night-bright-theme
+Docs: 
+Code: 
 
 ---
 
 # Underwater
+['dark', 'light']
 Repo: https://github.com/Seniblue/Underwater
-Docs: https://github.com/Seniblue/Underwater?tab=readme-ov-file#formatting
-Code: https://github.com/Seniblue/Underwater/blob/30ac787f0c178674e2f838471b487bc2649b223f/theme.css#L1341
+Docs: 
+Code: 
 
-Uses 'Tweaked' Minimal.
+---
 
-- [ ] Task  `- [ ]`
-- [x] Done `- [x]`
-- [-] Cancelled `- [-]`
-- [/] In Progress `- [/]`
-- [i] Info `- [i]`
+# Celestial Night
+['dark']
+Repo: https://github.com/Bluemoondragon07/Obsidian-Celestial-Night-Theme
+Docs: 
+Code: 
 
-- [!] Important `- [!]`
-- [l] Location `- [l]`
-- [*] Star `- [*]`
-- [H] Heart `- [H]`
-- [b] Bookmark `- [b]`
-- [<] Scheduled `- [<]`
-- [e] Energy `- [e]`
-- [T] Timer `- [T]`
-- [I] Idea `- [I]`
-- [s] Sparkles `- [s]`
-- [w] Wave `- [w]`
+---
+
+# Nightingale
+['dark']
+Repo: https://github.com/frank0713/nightingale-obsidian
+Docs: 
+Code: 
+
+---
+
+# Sanguine
+['dark']
+Repo: https://github.com/Satchelmouth/Obsidian-Theme-Sanguine
+Docs: 
+Code: 
 
 ---
 
 # Reshi
+['dark', 'light']
 Repo: https://github.com/contrapasso3/Reshi
-Docs: https://github.com/contrapasso3/Reshi?tab=readme-ov-file#features
-Code: https://github.com/contrapasso3/Reshi/blob/879377560c0661822d3cb217165c998f9c231812/theme.css#L591
+Docs: 
+Code: 
 
-"Feature inspiration pulled from AnuPpuccin"
+---
 
-- [/] In Progress `- [/]`
-- [-] Cancelled `- [-]`
-- [<] Scheduled `- [<]`
-- [>] Rescheduled `- [>]`
+# Transient
+['dark']
+Repo: https://github.com/GeorgeAzma/Transient
+Docs: 
+Code: 
 
-- [!] Important `- [!]`
-- [?] Question `- [?]`
-- [i] Information `- [i]`
-- [S] Amount `- [S]`
+---
 
-- [p] Pro `- [p]`
-- [c] Con `- [c]`
-
-- [n] Note `- [n]`
-- [I] Idea `- [I]`
-- [b] Bookmark `- [b]`
-- [*] Star `- [*]`
-- [k] Key `- [k]`
-- [t] Time `- [t]`
-- [l] Location `- [l]`
-- ["] Quote `- ["]`
+# Arcane
+['dark']
+Repo: https://github.com/xRyul/obsidian-arcane-theme
+Docs: 
+Code: 
 
 ---
 
 # Shade Sanctuary
+['dark', 'light']
 Repo: https://github.com/Elevict/Shade-Sanctuary
-Docs: None
-Code: https://github.com/Elevict/Shade-Sanctuary/blob/8aa1fcde7b3ab7be6475dc0bb978bf156d617779/theme.css#L614
+Docs: 
+Code: 
 
-Mentions using Minimal but has the Git parts from Things.
+---
 
-- [ ] To-Do `- [ ]`
-- [/] Incomplete `- [/]`
-- [x] Done `- [x]`
-- [-] Cancelled `- [-]`
-- [>] Forwarded `- [>]`
-- [<] Scheduling `- [<]`
+# Green Nightmare
+['dark']
+Repo: https://github.com/prradox/green-nightmare
+Docs: 
+Code: 
 
-- [?] Question `- [?]`
-- [!] Important `- [!]`
-- [*] Star `- [*]`
-- ["] Quote `- ["]`
-- [l] Location `- [l]`
-- [b] Bookmark `- [b]`
-- [i] Information `- [i]`
-- [S] Savings `- [S]`
-- [I] Idea `- [I]`
-- [p] Pros `- [p]`
-- [c] Cons `- [c]`
-- [f] Fire `- [f]`
-- [k] Key `- [k]`
-- [w] Win `- [w]`
-- [u] Up `- [u]`
-- [d] Down `- [d]`
+---
 
-- [D] Draft Pull Request `- [D]`
-- [P] Open Pull Request `- [P]`
-- [M] Merged Pull Request `- [M]`
+# Oldsidian Purple
+['dark']
+Repo: https://github.com/ltctceplrm/oldsidian-purple
+Docs: 
+Code: 
+
+---
+
+# Vibrant
+['dark']
+Repo: https://github.com/JamesLemony/obsidian_vibrant
+Docs: 
+Code: 
+
+---
+
+# Vanilla Palettes
+['light', 'dark']
+Repo: https://github.com/GnRlLeclerc/Vanilla-Theme-Palettes
+Docs: 
+Code: 
+
+---
+
+# Minimal-Resources
+['dark']
+Repo: https://github.com/jonsnow231/Minimal-Resources
+Docs: 
+Code: 
 
 ---
 
 # Sparkling Day
+['light']
 Repo: https://github.com/isax785/obsidian-sparkling-day
-Docs: https://github.com/isax785/obsidian-sparkling-day?tab=readme-ov-file#sparkling-checkboxes
-Code: https://github.com/isax785/obsidian-sparkling-day/blob/0dbcf1f4bcf660db7b17b6b0c376f9e3511cd71b/theme.css#L223
+Docs: 
+Code: 
 
-Only works in Live Preview.
+---
 
-- [>] Working Progress `- [>]`
-- [-] Pause / Stand-By `- [-]`
-- [/] Stop `- [/]`
-- [<] To Be Scheduled `- [<]`
+# Covert
+['dark']
+Repo: https://github.com/schrunchee/obsidian-covert-theme
+Docs: 
+Code: 
+
+---
+
+# Focus
+['dark']
+Repo: https://github.com/mProjectsCode/obsidian-focus-theme
+Docs: 
+Code: 
+
+---
+
+# Nier
+['dark']
+Repo: https://github.com/exloseur3d/nier-theme
+Docs: 
+Code: 
+
+---
+
+# EvilRed
+['dark']
+Repo: https://github.com/tu2-atmanand/EvilRed-ObsidianTheme
+Docs: 
+Code: 
+
+---
+
+# Venom
+['dark']
+Repo: https://github.com/fatiger92/obsidian_venom_theme
+Docs: 
+Code: 
+
+---
+
+# Poimandres
+['dark']
+Repo: https://github.com/yoGhastly/poimandres-obsidian
+Docs: 
+Code: 
+
+---
+
+# Sea Glass
+['dark']
+Repo: https://github.com/KStew1017/obsidian-sea-glass-theme
+Docs: 
+Code: 
+
+---
+
+# mono black (monochrome, charcoal)
+['dark']
+Repo: https://github.com/ZeChArtiahSaher/obsidian-mono-black
+Docs: 
+Code: 
+
+---
+
+# Oozy
+['dark']
+Repo: https://github.com/zaklezaja/obsidian-oozy
+Docs: 
+Code: 
+
+---
+
+# Strict
+['dark']
+Repo: https://github.com/Nikolai2038/strict-obsidian-theme
+Docs: 
+Code: 
+
+---
+
+# Prussian Blue
+['dark']
+Repo: https://github.com/EddieTheEd/Prussian-Blue
+Docs: 
+Code: 
 
 ---
 
 # Oreo
+['light', 'dark']
 Repo: https://github.com/carols12352/Oreo-theme
-Docs: https://github.com/carols12352/Oreo-theme?tab=readme-ov-file#check-box
-Code: https://github.com/carols12352/Oreo-theme/blob/1d4806a2c39ac46f6efbf3805652a52c695e3b04/theme.css#L752
-
-Uses the same set as Things / Minimal themes.
-
-- [ ] To-Do `- [ ]`
-- [/] Incomplete `- [/]`
-- [x] Done `- [x]`
-- [-] Cancelled `- [-]`
-- [>] Forwarded `- [>]`
-- [<] Scheduling `- [<]`
-
-- [?] Question `- [?]`
-- [!] Important `- [!]`
-- [*] Star `- [*]`
-- ["] Quote `- ["]`
-- [l] Location `- [l]`
-- [b] Bookmark `- [b]`
-- [i] Information `- [i]`
-- [S] Savings `- [S]`
-- [I] Idea `- [I]`
-- [p] Pros `- [p]`
-- [c] Cons `- [c]`
-- [f] Fire `- [f]`
-- [k] Key `- [k]`
-- [w] Win `- [w]`
-- [u] Up `- [u]`
-- [d] Down `- [d]`
-
-- [D] Draft Pull Request `- [D]`
-- [P] Open Pull Request `- [P]`
-- [M] Merged Pull Request `- [M]`
+Docs: 
+Code: 
 
 ---
 
-# Gummy Revived
+# Space
+['dark']
+Repo: https://github.com/bhappen/obsidian-space
+Docs: 
+Code: 
+
+---
+
+# Vanilla AMOLED Color
+['dark']
+Repo: https://github.com/Sskki-exe/vanilla-amoled-theme-color
+Docs: 
+Code: 
+
+---
+
+# Tomorrow
+['dark']
+Repo: https://github.com/deudz/obsidian-tomorrow-theme
+Docs: 
+Code: 
+
+---
+
+# DarkNebula
+['dark']
+Repo: https://github.com/HW9636/DarkNebulaObsidianTheme
+Docs: 
+Code: 
+
+---
+
+# Gummy-Revived
+['dark', 'light']
 Repo: https://github.com/WinnerWind/gummy-revived
-Docs: None (Partially based on Sanctum theme)
-Code: https://github.com/WinnerWind/gummy-revived/blob/bce022a254fa86645182f6f906a03a197629cf81/theme.css#L2235
-
-- [x] Done `- [x]`
-- [!] Important `- [!]`
-- [?] Question `- [?]`
-- [/] Progress `- [/]`
-- [-] Cancel `- [-]`
-- [>] Defer `- [>]`
-- [<] Scheduling `- [<]`
-- [X] Failed `- [X]`
-- [i] Idea `- [i]`
-- [b] Brainstorm `- [b]`
-- [B] Bookmark  `- [B]`
+Docs: 
+Code: 
 
 ---
+
+# Lorens
+['dark']
+Repo: https://github.com/lorens-osman-dev/Lorens-Obsidian-Theme
+Docs: 
+Code: 
+
+---
+
+# Dark Castle
+['dark']
+Repo: https://github.com/scottgriv/Dark-Castle-Obsidian
+Docs: 
+Code: 
+
+---
+
+# Neon Synthwave
+['dark']
+Repo: https://github.com/grjsmith/Neon-Synthwave
+Docs: 
+Code: 
+
+---
+
+# Midnight
+['dark']
+Repo: https://github.com/SemiCirkle/Midnight-obsidian-theme
+Docs: 
+Code: 
+
+---
+
+# Eldritch
+['dark']
+Repo: https://github.com/eldritch-theme/eldritch-obsidian
+Docs: 
+Code: 
+
+---
+
+# Rift
+['dark']
+Repo: https://github.com/NoahBoos/Obsidian-Theme-Rift
+Docs: 
+Code: 
+
+---
+
+# Blossom
+['dark']
+Repo: https://github.com/BlossomTheme/Obsidian
+Docs: 
+Code: 
+
+---
+
+# Kurokula
+['dark']
+Repo: https://github.com/Indyandie/kurokula-obsidian-theme
+Docs: 
+Code: 
+
+---
+
+# Muted-Blue
+['dark']
+Repo: https://github.com/HasanTheSyrian/Muted-Blue-Obsidian
+Docs: 
+Code: 
+
+---
+
+# Cobalt Peacock
+['dark']
+Repo: https://github.com/dpavaoman/cobalt-peacock-obmd
+Docs: 
+Code: 
+
+---
+
+# Spectrum Blue
+['dark']
+Repo: https://github.com/ryanjrman/Spectrum-Blue
+Docs: 
+Code: 
+
+---
+
+# Evergreen-Shadow
+['dark']
+Repo: https://github.com/Quinta0/Evergreen-Shadow
+Docs: 
+Code: 
+
+---
+
+# Trace Labs
+['dark']
+Repo: https://github.com/humandecoded/Trace-Labs-Obsidian-Theme
+Docs: 
+Code: 
+
+---
+
+# Bossidian
+['dark']
+Repo: https://github.com/BossElijah/bossidian
+Docs: 
+Code: 
+
+---
+
+# Black
+['dark']
+Repo: https://github.com/b3h3m0th/black-obsidian-theme
+Docs: 
+Code: 
+
+---
+
+# nobb
+['dark']
+Repo: https://github.com/buluw/nobb-obsidian
+Docs: 
+Code: 
+
+---
+
+# Velvet-Moon
+['dark']
+Repo: https://github.com/Quinta0/Velvet-Moon
+Docs: 
+Code: 
+
+---
+
+# Midnight-Fjord
+['dark']
+Repo: https://github.com/Quinta0/Midnight-Fjord
+Docs: 
+Code: 
+
+---
+
+# Rose Red
+['dark']
+Repo: https://github.com/tu2-atmanand/RoseRed-ObsidianTheme
+Docs: 
+Code: 

--- a/Themes - Alternative Checkboxes.md
+++ b/Themes - Alternative Checkboxes.md
@@ -522,11 +522,18 @@ Code:
 
 ---
 
-# Spectrum
-['dark', 'light']
-Repo: https://github.com/Braweria/Spectrum
-Docs: 
-Code: 
+# Spectrum (Unmaintained Pre-1.0 Release)
+
+Repo: https://github.com/wiktoriavh/Spectrum
+Docs: https://github.com/wiktoriavh/Spectrum/wiki/Different-Task-Checkboxes
+Code: https://github.com/wiktoriavh/Spectrum/blob/6c24513a3af57a7ebaeff63df7e62bf47513efac/SCSS/_blocks/_listings/_task-list.scss#L63
+
+- [>] Forward `- [>]`
+- [+] Plus `- [+]`
+- [-] Minus `- [-]`
+- [!] Exclamation `- [!]`
+- [?] Question `- [?]`
+- [x] Normal `- [x]`
 
 ---
 

--- a/Themes - Alternative Checkboxes.md
+++ b/Themes - Alternative Checkboxes.md
@@ -1057,10 +1057,16 @@ Code:
 ---
 
 # Sparkling Night
-['dark', 'light']
 Repo: https://github.com/isax785/obsidian-sparkling-night
-Docs: 
-Code: 
+Docs: https://github.com/isax785/obsidian-sparkling-night
+Code: https://github.com/isax785/obsidian-sparkling-night/blob/e7436b653c0c287a5f8a3c246d8a301107a4edfa/theme.css#L256
+
+Only works in Live Preview.
+
+- [>] Working Progress `- [>]`
+- [-] Pause / Stand-By `- [-]`
+- [/] Stop `- [/]`
+- [<] To Be Scheduled `- [<]`
 
 ---
 
@@ -1073,10 +1079,19 @@ Code:
 ---
 
 # Kakano
-['dark', 'light']
+
 Repo: https://github.com/isaacfreeman/kakano-obsidian-theme
-Docs: 
-Code: 
+Docs: https://github.com/isaacfreeman/kakano-obsidian-theme?tab=readme-ov-file#selected-alternate-checkboxes
+Code: https://github.com/isaacfreeman/kakano-obsidian-theme/blob/2e4e869043eca019839ef8b6b774196edb81211b/theme.css#L2082
+
+"Idea borrowed from Minimal theme"
+
+- [/] Partially `- [/]`
+- [<] Scheduling `- [<]`
+- [-] Cancelled `- [-]`
+- [>] Forwarded `- [>]`
+- [!] Important `- [!]`
+- [?] Question `- [?]`
 
 ---
 
@@ -1097,18 +1112,79 @@ Code:
 ---
 
 # Neo
-['dark', 'light']
 Repo: https://github.com/lab-do/obsidian-neo
-Docs: 
-Code: 
+Docs: https://github.com/lab-do/obsidian-neo?tab=readme-ov-file#alternate-checkboxes
+Code: https://github.com/lab-do/obsidian-neo/blob/0955f59136e498461a2de78655eef42cbcf66606/theme.css#L999
+
+- [ ] Checkbox `- [ ]`
+- [x] Complete `- [x]`
+- [/] Incomplete `- [/]`
+- [-] Cancelled `- [-]`
+- [>] Forwarded `- [>]`
+- [<] Schedule `- [<]`
+
+- [i] Info `- [i]`
+- [I] Idea `- [I]`
+- [!] Important `- [!]`
+- [?] Question `- [?]`
+- [p] Pros `- [p]`
+- [c] Cons `- [c]`
+
+- [f] Fire `- [f]`
+- [*] Star `- [*]`
+- [b] Bookmark `- [b]`
+- [u] Trend Up `- [u]`
+- [d] Trend Down `- [d]`
+- [w] Win `- [w]`
+
+- [k] Key `- [k]`
+- ["] Quote `- ["]`
+- [S] Money `- [S]`
+- [l] Location `- [l]`
+- [n] New `- [n]`
+
+- [0] Progress 0 `- [0]`
+- [1] Progress 1 `- [1]`
+- [2] Progress 2 `- [2]`
+- [3] Progress 3 `- [3]`
+- [4] Progress 4 `- [4]`
 
 ---
 
 # Feather
-['dark', 'light']
-Repo: https://github.com/MFdev-coder/obsidian-feather
-Docs: 
-Code: 
+Repo: https://github.com/zfmohammed/obsidian-feather
+Docs: https://github.com/zfmohammed/obsidian-feather?tab=readme-ov-file#themes (Screenshots)
+Code: https://github.com/zfmohammed/obsidian-feather/blob/da83afd4dd10ba387a7eee59c00f0b8e022d3748/theme.css#L162
+
+Mentions using Things Theme for Checkboxes.
+
+- [ ] To-Do `- [ ]`
+- [/] Incomplete `- [/]`
+- [x] Done `- [x]`
+- [-] Cancelled `- [-]`
+- [>] Forwarded `- [>]`
+- [<] Scheduling `- [<]`
+
+- [?] Question `- [?]`
+- [!] Important `- [!]`
+- [*] Star `- [*]`
+- ["] Quote `- ["]`
+- [l] Location `- [l]`
+- [b] Bookmark `- [b]`
+- [i] Information `- [i]`
+- [S] Savings `- [S]`
+- [I] Idea `- [I]`
+- [p] Pros `- [p]`
+- [c] Cons `- [c]`
+- [f] Fire `- [f]`
+- [k] Key `- [k]`
+- [w] Win `- [w]`
+- [u] Up `- [u]`
+- [d] Down `- [d]`
+
+- [D] Draft Pull Request `- [D]`
+- [P] Open Pull Request `- [P]`
+- [M] Merged Pull Request `- [M]`
 
 ---
 
@@ -1153,18 +1229,99 @@ Code:
 ---
 
 # Listive
-['dark', 'light']
 Repo: https://github.com/efemkay/obsidian-listive-theme
-Docs: 
-Code: 
+Docs: https://github.com/efemkay/obsidian-listive-theme?tab=readme-ov-file#list-related-features (Mentions taking Checkboxes from Border Theme)
+Code: https://github.com/efemkay/obsidian-listive-theme/blob/698f27ce12d23ee451712639df9c4b429019f751/theme.css#L1070
+
+- [/] Partial / Incomplete `- [/]`
+- [>] Defer / Reschedule `- [>]`
+- [-] Cancelled `- [-]`
+- [<] Schedule / Meeting `- [<]`
+- [I] Idea / Light Bulb `- [I]`
+- [i] Info `- [i]`
+- [!] Warning `- [!]`
+- ["] Citation, my version `- ["]`
+- [r] Reference `- [r]`
+- [*] Star / Favourites `- [*]`
 
 ---
 
 # MagicUser
-['dark', 'light']
 Repo: https://github.com/drbap/magicuser-theme-for-obsidian
-Docs: 
-Code: 
+Docs: https://github.com/drbap/magicuser-theme-for-obsidian?tab=readme-ov-file#custom-checkbox-icons
+Code: https://github.com/drbap/magicuser-theme-for-obsidian/blob/33ebb74f4355cd4a46725415ea328ad9781ad46e/theme.css#L1382
+
+- [ ] Unchecked `- [ ]`
+- [x] Checked `- [x]`
+- [-] Cancelled `- [-]`
+
+- [/] Work in Progress `- [/]`
+- [g] Results / Graphics / Stats `- [g]`
+
+- [!] Important `- [!]`
+- [?] Question  `- [?]`
+- [i] Information `- [i]`
+- [I] Idea `- [I]`
+
+- [<] Date - Scheduled `- [<]`
+- [>] Date - Rescheduled `- [>]`
+- [e] Email `- [e]`
+- [t] Time `- [t]`
+- [f] Phone `- [f]`
+- [F] Flight `- [F]`
+
+- [l] Location `- [l]`
+- [b] Bookmark `- [b]`
+- [q] Quote `- [q]` or `- ["]`
+
+- [p] Pro `- [p]`
+- [c] Con `- [c]`
+
+- [1] Arrow Up - Increase `- [1]`
+- [2] Arrow Down - Decrease `- [2]`
+- [3] Arrow Right `- [3]`
+
+- [s] Star `- [s]` or `- [*]`
+- [S] Price / Money `- [S]`
+- [n] Note `- [n]`
+
+- [m] Magic Wand `- [m]`
+
+**Extra 1**
+- [k] Key `- [k]`
+- [w] Win `- [w]`
+- [u] Up `- [u]`
+- [d] Down `- [d]`
+
+- [D] Draft Pull Request `- [D]`
+- [P] Open Pull Request `- [P]`
+- [M] Merged Pull Request  `- [M]`
+
+**Extra 2**
+- [B] Branch `- [B]`
+- [T] Test `- [T]`
+
+- [o] Issue `- [o]`
+- [O] Closed Issue `- [O]`
+
+- [U] User `- [U]`
+- [W] Password `- [W]`
+- [C] Cart / Buy `- [C]`
+- [a] Add / Plus `- [a]`
+- [r] Remove / Minus  `- [r]`
+
+**Extra 3**
+- [G] Group / Users `- [G]`
+
+- [R] Reference / Repository `- [R]`
+- [E] Eye / View `- [E]`
+- [A] Activity `- [A]`
+- [L] Lesson / Presentation `- [L]`
+
+- [h] Home `- [h]`
+- [H] Health / Fitness `- [H]`
+
+- [Q] Quality `- [Q]`
 
 ---
 
@@ -1345,10 +1502,16 @@ Code:
 ---
 
 # Qlean
-['dark', 'light']
 Repo: https://github.com/Fro-Q/Qlean
-Docs: 
-Code: 
+Docs: https://github.com/Fro-Q/Qlean/blob/main/assets/checkbox_style.png
+Code: https://github.com/Fro-Q/Qlean/blob/619efd313553e6cb6ce7a8c12cc05cf080e8e8df/theme.css#L672
+
+- [ ] Unchecked `- [ ]`
+- [x] Checked `- [x]`
+- [-] Cancelled? `- [-]`
+- [?] Question? `- [?]`
+- [!] Important? `- [!]`
+- [i] Information? `- [i]`
 
 ---
 
@@ -1369,10 +1532,35 @@ Code:
 ---
 
 # Yue
-['light', 'dark']
-Repo: https://github.com/thegixo/YueObsidian
-Docs: 
-Code: 
+Repo:https://github.com/GixoXYZ/YueObsidian
+Docs: https://github.com/GixoXYZ/YueObsidian?tab=readme-ov-file#checkbox-styling
+Code: https://github.com/GixoXYZ/YueObsidian/blob/fb138cf9b31396b20110c32082a76bd5d6cd8d1d/theme.css#L634
+
+Same as Minimal.
+
+- [ ] To-Do `- [ ]`
+- [/] Incomplete `- [/]`
+- [x] Done `- [x]`
+- [-] Cancelled `- [-]`
+- [>] Forwarded `- [>]`
+- [<] Scheduling `- [<]`
+
+- [?] Question `- [?]`
+- [!] Important `- [!]`
+- [*] Star `- [*]`
+- ["] Quote `- ["]`
+- [l] Location `- [l]`
+- [b] Bookmark `- [b]`
+- [i] Information `- [i]`
+- [S] Savings `- [S]`
+- [I] Idea `- [I]`
+- [p] Pros `- [p]`
+- [c] Cons `- [c]`
+- [f] Fire `- [f]`
+- [k] Key `- [k]`
+- [w] Win `- [w]`
+- [u] Up `- [u]`
+- [d] Down `- [d]`
 
 ---
 
@@ -1401,10 +1589,28 @@ Code:
 ---
 
 # sQdthOne
-['dark', 'light']
 Repo: https://github.com/KeithLerner/ObsidianMDsQdthOne
-Docs: 
-Code: 
+Docs: None
+Code: https://raw.githubusercontent.com/KeithLerner/ObsidianMDsQdthOne/refs/heads/main/theme.css
+
+- [>] Forwarded `- [>]`
+- [<] Schedule `- [<]`
+- [u] Up `- [u]`
+- [d] Down `- [d]`
+- [/] Incomplete `- [/]`
+- [?] Question `- [?]`
+- [!] Important `- [!]`
+- [i] Info `- [i]`
+- [*] Star `- [*]`
+- [+] Added `- [+]`
+- [-] Cancelled `- [-]`
+- [p] Pros `- [p]`
+- [c] Cons `- [c]`
+- [b] Bookmark `- [b]`
+- [l] Location `- [l]`
+- [s] Smile :) `- [s]`
+- [k] Key `- [k]`
+- [f] Fire `- [f]`
 
 ---
 
@@ -1569,10 +1775,49 @@ Code:
 ---
 
 # Prime
-['dark', 'light']
 Repo: https://github.com/rivea0/obsidian-prime
-Docs: 
-Code: 
+Docs: https://github.com/rivea0/obsidian-prime?tab=readme-ov-file#custom-checkbox-styling
+Code: https://github.com/rivea0/obsidian-prime/blob/main/theme.css#L1774
+
+Uses the same set as Minimal theme and some from Things theme.
+
+- [ ] to do `- [ ]`
+- [/] incomplete `- [/]`
+- [x] done `- [x]`
+- [-] cancelled `- [-]`
+- [>] forwarded `- [>]`
+- [<] scheduling `- [<]`
+
+- [?] question `- [?]`
+- [!] important `- [!]`
+- [*] star `- [*]`
+- ["] quote `- ["]`
+- [l] location `- [l]`
+- [b] bookmark `- [b]`
+- [i] information `- [i]`
+- [S] savings `- [S]`
+- [I] idea `- [I]`
+- [p] pros `- [p]`
+- [c] cons `- [c]`
+- [f] fire `- [f]`
+- [k] key `- [k]`
+- [w] win `- [w]`
+- [u] up `- [u]`
+- [d] down `- [d]`
+- [D] draft pull request `- [D]`
+- [P] open pull request `- [P]`
+- [M] merged pull request `- [M]`
+
+- [m] mail `- [m]`
+- [h] heart `- [h]`
+- [a] archive `- [a]`
+- [e] eye `- [e]`
+- [s] search `- [s]`
+- [r] rocket `- [r]`
+- [8] infinity `- [8]`
+- [g] goal `- [g]`
+- [+] positive `- [+]`
+- [n] negative `- [n]`
 
 ---
 
@@ -1600,11 +1845,42 @@ Code:
 
 ---
 
-# Sanctum reborn
-['dark', 'light']
+# Sanctum Reborn
 Repo: https://github.com/antoKeinanen/obsidian-sanctum-reborn
-Docs: 
-Code: 
+Docs: https://github.com/antoKeinanen/obsidian-sanctum-reborn/blob/main/documentation/Theme_Guide.md#features
+Code: https://github.com/antoKeinanen/obsidian-sanctum-reborn/blob/main/src/scss/features/custom-checkboxes.scss
+
+- [*] Star `- [*]`
+- [a] Reminder `- [a]`
+- [f] Favorite `- [f]`
+- [S] Savings `- [S]`
+- [-] Cancelled `- [-]`
+- [>] Rescheduled `- [>]`
+- [<] Scheduled `- [<]`
+- [l] Location `- [l]`
+- [B] Bug `- [B]`
+- [X] Failure `- [X]`
+- [n] Annotation `- [n]`
+- [p] Pros `- [p]`
+- [c] Cons `- [c]`
+- [w] Win `- [w]`
+- [b] Bookmark `- [b]`
+- [I] Idea `- [I]`
+- [!] Warning `- [!]`
+- [?] Question `- [?]`
+- [i] Info `- [i]`
+- [/] In Progress `- [/]`
+- [u] Trend Up `- [u]`
+- [d] Trend Down `- [d]`
+- [F] Feature `- [F]`
+- [r] Law `- [r]`
+- [m] Measurement `- [m]`
+- [M] Medical `- [M]`
+- [L] Language `- [L]`
+- [t] Time `- [t]`
+- [T] Call `- [T]`
+- [P] Person `- [P]`
+- [s] Money `- [s]`
 
 ---
 

--- a/Themes - Alternative Checkboxes.md
+++ b/Themes - Alternative Checkboxes.md
@@ -1901,10 +1901,29 @@ Code:
 ---
 
 # Underwater
-['dark', 'light']
 Repo: https://github.com/Seniblue/Underwater
-Docs: 
-Code: 
+Docs: https://github.com/Seniblue/Underwater?tab=readme-ov-file#formatting
+Code: https://github.com/Seniblue/Underwater/blob/30ac787f0c178674e2f838471b487bc2649b223f/theme.css#L1341
+
+Uses 'Tweaked' Minimal.
+
+- [ ] Task  `- [ ]`
+- [x] Done `- [x]`
+- [-] Cancelled `- [-]`
+- [/] In Progress `- [/]`
+- [i] Info `- [i]`
+
+- [!] Important `- [!]`
+- [l] Location `- [l]`
+- [*] Star `- [*]`
+- [H] Heart `- [H]`
+- [b] Bookmark `- [b]`
+- [<] Scheduled `- [<]`
+- [e] Energy `- [e]`
+- [T] Timer `- [T]`
+- [I] Idea `- [I]`
+- [s] Sparkles `- [s]`
+- [w] Wave `- [w]`
 
 ---
 
@@ -1933,10 +1952,33 @@ Code:
 ---
 
 # Reshi
-['dark', 'light']
 Repo: https://github.com/contrapasso3/Reshi
-Docs: 
-Code: 
+Docs: https://github.com/contrapasso3/Reshi?tab=readme-ov-file#features
+Code: https://github.com/contrapasso3/Reshi/blob/879377560c0661822d3cb217165c998f9c231812/theme.css#L591
+
+"Feature inspiration pulled from AnuPpuccin"
+
+- [/] In Progress `- [/]`
+- [-] Cancelled `- [-]`
+- [<] Scheduled `- [<]`
+- [>] Rescheduled `- [>]`
+
+- [!] Important `- [!]`
+- [?] Question `- [?]`
+- [i] Information `- [i]`
+- [S] Amount `- [S]`
+
+- [p] Pro `- [p]`
+- [c] Con `- [c]`
+
+- [n] Note `- [n]`
+- [I] Idea `- [I]`
+- [b] Bookmark `- [b]`
+- [*] Star `- [*]`
+- [k] Key `- [k]`
+- [t] Time `- [t]`
+- [l] Location `- [l]`
+- ["] Quote `- ["]`
 
 ---
 
@@ -1957,10 +1999,39 @@ Code:
 ---
 
 # Shade Sanctuary
-['dark', 'light']
 Repo: https://github.com/Elevict/Shade-Sanctuary
-Docs: 
-Code: 
+Docs: None
+Code: https://github.com/Elevict/Shade-Sanctuary/blob/8aa1fcde7b3ab7be6475dc0bb978bf156d617779/theme.css#L614
+
+Mentions using Minimal but has the Git parts from Things.
+
+- [ ] To-Do `- [ ]`
+- [/] Incomplete `- [/]`
+- [x] Done `- [x]`
+- [-] Cancelled `- [-]`
+- [>] Forwarded `- [>]`
+- [<] Scheduling `- [<]`
+
+- [?] Question `- [?]`
+- [!] Important `- [!]`
+- [*] Star `- [*]`
+- ["] Quote `- ["]`
+- [l] Location `- [l]`
+- [b] Bookmark `- [b]`
+- [i] Information `- [i]`
+- [S] Savings `- [S]`
+- [I] Idea `- [I]`
+- [p] Pros `- [p]`
+- [c] Cons `- [c]`
+- [f] Fire `- [f]`
+- [k] Key `- [k]`
+- [w] Win `- [w]`
+- [u] Up `- [u]`
+- [d] Down `- [d]`
+
+- [D] Draft Pull Request `- [D]`
+- [P] Open Pull Request `- [P]`
+- [M] Merged Pull Request `- [M]`
 
 ---
 
@@ -2005,10 +2076,16 @@ Code:
 ---
 
 # Sparkling Day
-['light']
 Repo: https://github.com/isax785/obsidian-sparkling-day
-Docs: 
-Code: 
+Docs: https://github.com/isax785/obsidian-sparkling-day?tab=readme-ov-file#sparkling-checkboxes
+Code: https://github.com/isax785/obsidian-sparkling-day/blob/0dbcf1f4bcf660db7b17b6b0c376f9e3511cd71b/theme.css#L223
+
+Only works in Live Preview.
+
+- [>] Working Progress `- [>]`
+- [-] Pause / Stand-By `- [-]`
+- [/] Stop `- [/]`
+- [<] To Be Scheduled `- [<]`
 
 ---
 
@@ -2101,10 +2178,40 @@ Code:
 ---
 
 # Oreo
-['light', 'dark']
 Repo: https://github.com/carols12352/Oreo-theme
-Docs: 
-Code: 
+Docs: https://github.com/carols12352/Oreo-theme?tab=readme-ov-file#check-box
+Code: https://github.com/carols12352/Oreo-theme/blob/1d4806a2c39ac46f6efbf3805652a52c695e3b04/theme.css#L752
+
+Uses the same set as Things / Minimal themes.
+
+- [ ] To-Do `- [ ]`
+- [/] Incomplete `- [/]`
+- [x] Done `- [x]`
+- [-] Cancelled `- [-]`
+- [>] Forwarded `- [>]`
+- [<] Scheduling `- [<]`
+
+- [?] Question `- [?]`
+- [!] Important `- [!]`
+- [*] Star `- [*]`
+- ["] Quote `- ["]`
+- [l] Location `- [l]`
+- [b] Bookmark `- [b]`
+- [i] Information `- [i]`
+- [S] Savings `- [S]`
+- [I] Idea `- [I]`
+- [p] Pros `- [p]`
+- [c] Cons `- [c]`
+- [f] Fire `- [f]`
+- [k] Key `- [k]`
+- [w] Win `- [w]`
+- [u] Up `- [u]`
+- [d] Down `- [d]`
+
+- [D] Draft Pull Request `- [D]`
+- [P] Open Pull Request `- [P]`
+- [M] Merged Pull Request `- [M]`
+
 
 ---
 
@@ -2140,11 +2247,23 @@ Code:
 
 ---
 
-# Gummy-Revived
-['dark', 'light']
+# Gummy Revived
 Repo: https://github.com/WinnerWind/gummy-revived
-Docs: 
-Code: 
+Docs: None (Partially based on Sanctum theme)
+Code: https://github.com/WinnerWind/gummy-revived/blob/bce022a254fa86645182f6f906a03a197629cf81/theme.css#L2235
+
+- [x] Done `- [x]`
+- [!] Important `- [!]`
+- [?] Question `- [?]`
+- [/] Progress `- [/]`
+- [-] Cancel `- [-]`
+- [>] Defer `- [>]`
+- [<] Scheduling `- [<]`
+- [X] Failed `- [X]`
+- [i] Idea `- [i]`
+- [b] Brainstorm `- [b]`
+- [B] Bookmark  `- [B]`
+
 
 ---
 

--- a/Themes - Alternative Checkboxes.md
+++ b/Themes - Alternative Checkboxes.md
@@ -985,14 +985,6 @@ Code: https://github.com/zaheralmajed/vicious-theme-obsidian/blob/686d487e0705fd
 
 ---
 
-# Simple
-['dark', 'light']
-Repo: https://github.com/diegoeis/simple-obsidian
-Docs: 
-Code: 
-
----
-
 # Elegance
 
 Repo: https://github.com/Victologo/elegance-theme
@@ -1022,6 +1014,41 @@ Code: https://github.com/Victologo/elegance-theme/blob/83947941e3f44fb4f37df291c
 - [w] Win `- [w]`
 - [u] Up `- [u]`
 - [d] Down `- [d]`
+
+---
+
+# Simple
+Repo: https://github.com/diegoeis/simple-obsidian
+Docs: https://github.com/diegoeis/simple-obsidian?tab=readme-ov-file#checklists-styles
+Code: https://github.com/diegoeis/simple-obsidian/blob/2b45f172c7c0840dcf94d173ddf89b2a1ba53aa0/theme.css#L733
+
+Uses the same set as Things / Minimal themes.
+
+- [ ] To-Do `- [ ]`
+- [/] Incomplete `- [/]`
+- [x] Done `- [x]`
+- [-] Cancelled `- [-]`
+- [>] Forwarded `- [>]`
+- [<] Scheduling `- [<]`
+
+- [?] Question `- [?]`
+- [!] Important `- [!]`
+- [*] Star `- [*]`
+- ["] Quote `- ["]`
+- [l] Location `- [l]`
+- [b] Bookmark `- [b]`
+- [i] Information `- [i]`
+- [S] Savings `- [S]`
+- [I] Idea `- [I]`
+- [p] Pros `- [p]`
+- [c] Cons `- [c]`
+- [f] Fire `- [f]`
+- [k] Key `- [k]`
+- [w] Win `- [w]`
+- [u] Up `- [u]`
+- [d] Down `- [d]`
+
+---
 
 # Aurora
 ['dark']

--- a/Themes - Alternative Checkboxes.md
+++ b/Themes - Alternative Checkboxes.md
@@ -140,34 +140,155 @@ Themes are ordered from most popular to least popular at the time of writing.
 ---
 
 # Minimal
-['dark', 'light']
 Repo: https://github.com/kepano/obsidian-minimal
-Docs: 
-Code: 
+Docs: https://minimal.guide/checklists
+Code: https://github.com/kepano/obsidian-minimal/blob/master/src/scss/features/checklist-icons.scss
+
+- [ ] To-Do `- [ ]`
+- [/] Incomplete `- [/]`
+- [x] Done `- [x]`
+- [-] Cancelled `- [-]`
+- [>] Forwarded `- [>]`
+- [<] Scheduling `- [<]`
+
+- [?] Question `- [?]`
+- [!] Important `- [!]`
+- [*] Star `- [*]`
+- ["] Quote `- ["]`
+- [l] Location `- [l]`
+- [b] Bookmark `- [b]`
+- [i] Information `- [i]`
+- [S] Savings `- [S]`
+- [I] Idea `- [I]`
+- [p] Pros `- [p]`
+- [c] Cons `- [c]`
+- [f] Fire `- [f]`
+- [k] Key `- [k]`
+- [w] Win `- [w]`
+- [u] Up `- [u]`
+- [d] Down `- [d]`
 
 ---
 
 # Things
-['light', 'dark']
 Repo: https://github.com/colineckert/obsidian-things
-Docs: 
-Code: 
+Docs: https://github.com/colineckert/obsidian-things?tab=readme-ov-file#checkbox-styling
+Code: https://github.com/colineckert/obsidian-things/blob/9d0a8b44007a335ee829a0d3843ab579051eeb70/theme.css#L661
+
+- [ ] To-Do `- [ ]`
+- [/] Incomplete `- [/]`
+- [x] Done `- [x]`
+- [-] Cancelled `- [-]`
+- [>] Forwarded `- [>]`
+- [<] Scheduling `- [<]`
+
+- [?] Question `- [?]`
+- [!] Important `- [!]`
+- [*] Star `- [*]`
+- ["] Quote `- ["]`
+- [l] Location `- [l]`
+- [b] Bookmark `- [b]`
+- [i] Information `- [i]`
+- [S] Savings `- [S]`
+- [I] Idea `- [I]`
+- [p] Pros `- [p]`
+- [c] Cons `- [c]`
+- [f] Fire `- [f]`
+- [k] Key `- [k]`
+- [w] Win `- [w]`
+- [u] Up `- [u]`
+- [d] Down `- [d]`
+
+- [D] Draft Pull Request `- [D]`
+- [P] Open Pull Request `- [P]`
+- [M] Merged Pull Request `- [M]`
 
 ---
 
 # Blue Topaz
-['dark', 'light']
-Repo: https://github.com/whyt-byte/Blue-Topaz_Obsidian-css
-Docs: 
-Code: 
+Repo: https://github.com/PKM-er/Blue-Topaz_Obsidian-css
+Docs: https://github.com/PKM-er/Blue-topaz-example/blob/96ecdaa485f0b4e4b8c22c7fea4394be1b882c83/Demo%20Note.md?plain=1#L144
+Code:
+- https://github.com/PKM-er/Blue-Topaz_Obsidian-css/blob/d55ba0b88ee2d91b49bd5cce66039685c27073f4/theme.css#L11739
+- https://github.com/PKM-er/Blue-Topaz_Obsidian-css/blob/d55ba0b88ee2d91b49bd5cce66039685c27073f4/theme.css#L29306
+
+- [>] Rescheduled `- [>]`
+- [<] Scheduled `- [<]`
+- [!] Important `- [!]`
+- [-] Cancelled `- [-]`
+- [/] In Progress `- [/]`
+
+- ["] Quote`- ["]`
+- [?] Question `- [?]`
+- [*] Star `- [*]`
+- [n] Note `- [n]`
+- [l] Location `- [l]`
+- [i] Information `- [i]`
+- [I] Idea / Light bulb `- [I]`
+- [S] Amount `- [S]`
+- [p] Pro `- [p]`
+- [c] Con `- [c]`
+- [b] Bookmark `- [b]`
+- [f] Fire `- [f]`
+- [w] Win `- [w]`
+- [k] Key `- [k]`
+- [u] Up `- [u]`
+- [d] Down `- [d]`
+- [F] Feature `- [F]`
+- [r] Rule / Law `- [r]`
+- [m] Measurement `- [m]`
+- [M] Medical `- [M]`
+- [L] Translate / Language `- [L]`
+- [t] Clock / Time `- [t]`
+- [T] Telephone `- [T]`
+- [P] Person `- [P]`
+- [#] Tags `- [#]`
+- [W] World `- [W]`
+- [U] Universe `- [U]`
 
 ---
 
 # AnuPpuccin
-['dark', 'light']
+
 Repo: https://github.com/AnubisNekhet/AnuPpuccin
-Docs: 
-Code: 
+Docs: https://github.com/AnubisNekhet/AnuPpuccin?tab=readme-ov-file#custom-checkboxes--speech-bubbles
+Code: https://github.com/AnubisNekhet/AnuPpuccin/blob/main/src/modules/Features/custom-checkboxes.scss
+
+Style Settings Required: `AnuPpuccin -> File Editor & Markdown Elements -> Checkboxes -> Enable Custom Checkboxes`
+
+- [ ] Unchecked `- [ ]`
+- [x] Checked `- [x]`
+- [>] Rescheduled `- [>]`
+- [<] Scheduled `- [<]`
+- [!] Important `- [!]`
+- [-] Cancelled `- [-]`
+- [/] In Progress `- [/]`
+- [?] Question `- [?]`
+- [*] Star `- [*]`
+- [n] Note `- [n]`
+- [l] Location `- [l]`
+- [i] Information `- [i]`
+- [I] Idea `- [I]`
+- [S] Amount `- [S]`
+- [p] Pro `- [p]`
+- [c] Con `- [c]`
+- [b] Bookmark `- [b]`
+- ["] Quote `- ["]`
+- [u] Up `- [u]`
+- [d] Down `- [d]`
+- [w] Win `- [w]`
+- [k] Key `- [k]`
+- [f] Fire `- [f]`
+- [0] Speech bubble 0 `- [0]`
+- [1] Speech bubble 1 `- [1]`
+- [2] Speech bubble 2 `- [2]`
+- [3] Speech bubble 3 `- [3]`
+- [4] Speech bubble 4 `- [4]`
+- [5] Speech bubble 5 `- [5]`
+- [6] Speech bubble 6 `- [6]`
+- [7] Speech bubble 7 `- [7]`
+- [8] Speech bubble 8 `- [8]`
+- [9] Speech bubble 9 `- [9]`
 
 ---
 
@@ -180,10 +301,29 @@ Code:
 ---
 
 # Sanctum
-['dark', 'light']
 Repo: https://github.com/jdanielmourao/obsidian-sanctum
-Docs: 
-Code: 
+Docs: https://github.com/jdanielmourao/obsidian-sanctum/blob/main/documentation/Theme_Guide.md
+Code: https://github.com/jdanielmourao/obsidian-sanctum/blob/main/src/scss/features/custom-checkboxes.scss
+
+- [i] Information `- [i]`
+- [-] Cancelled `- [-]`
+- [<] Scheduled `- [<]`
+- [>] Rescheduled/Forwarded `- [>]`
+- [?] Question `- [?]`
+- [!] Important `- [!]`
+- [l] Location `- [l]`
+- [x] Task `- [x]`
+- [ ] Task `- [ ]`
+- [I] Idea `- [I]`
+- [p] Thumbs up `- [p]`
+- [c] Thumbs down `- [c]`
+- [S] Piggy bank `- [S]`
+- [s] Money `- [s]`
+- [a] Bell `- [a]`
+- [b] Bookmark `- [b]`
+- [n] Pin `- [n]`
+- [B] Bug `- [B]`
+- [W] Reward `- [W]`
 
 ---
 

--- a/Themes - Alternative Checkboxes.md
+++ b/Themes - Alternative Checkboxes.md
@@ -328,10 +328,48 @@ Code: https://github.com/jdanielmourao/obsidian-sanctum/blob/main/src/scss/featu
 ---
 
 # ITS Theme
-['dark', 'light']
 Repo: https://github.com/SlRvb/Obsidian--ITS-Theme
-Docs: 
-Code: 
+Docs: https://publish.obsidian.md/slrvb-docs/ITS+Theme/Alternate+Checkboxes
+Code: https://github.com/SlRvb/Obsidian--ITS-Theme/blob/main/SCSS/Alternate%20Checkboxes.scss
+
+- [ ] Unchecked `- [ ]`
+- [x] Regular `- [x]`
+- [X] Checked  `- [X]`
+- [-] Dropped  `- [-]`
+- [>] Forward  `- [>]`
+- [<] Migrated  `- [<]`
+- [D] Date  `- [D]`
+- [?] Question  `- [?]`
+- [/] Half Done  `- [/]`
+- [+] Add  `- [+]`
+- [R] Research  `- [R]`
+- [!] Important  `- [!]`
+- [i] Idea  `- [i]`
+- [B] Brainstorm  `- [B]`
+- [P] Pro  `- [P]`
+- [C] Con  `- [C]`
+- [Q] Quote  `- [Q]`
+- [N] Note  `- [N]`
+- [b] Bookmark  `- [b]`
+- [I] Information  `- [I]`
+- [p] Paraphrase  `- [p]`
+- [L] Location  `- [L]`
+- [E] Example  `- [E]`
+- [A] Answer  `- [A]`
+- [r] Reward `- [r]`
+- [c] Choice  `- [c]`
+- [d] Doing  `- [d]`
+- [T] Time  `- [T]`
+- [@] Character / Person  `- [@]`
+- [t] Talk  `- [t]`
+- [O] Outline / Plot  `- [O]`
+- [~] Conflict  `- [~]`
+- [W] World  `- [W]`
+- [f] Clue / Find  `- [f]`
+- [F] Foreshadow  `- [F]`
+- [H] Favorite / Health  `- [H]`
+- [&] Symbolism  `- [&]`
+- [s] Secret  `- [s]`
 
 ---
 
@@ -360,18 +398,64 @@ Code:
 ---
 
 # Primary
-['light', 'dark']
+
 Repo: https://github.com/primary-theme/obsidian
-Docs: 
-Code: 
+Docs: https://primary-theme.github.io/features/checkboxes/#checklists
+Code: https://github.com/primary-theme/obsidian/blob/main/src/scss/40_editor/_alt-checkboxes.scss
+
+- [/] In Progress `- [/]`
+- [>] Rescheduled `- [>]`
+- [<] Scheduled `- [<]`
+- [!] Important `- [!]`
+- [-] Cancelled `- [-]`
+- [?] Question `- [?]`
+- [*] Star `- [*]`
+- [n] Note `- [n]`
+- [l] Location `- [l]`
+- [i] Information `- [i]`
+- [S] Amount `- [S]`
+- ["] Quote `- ["]`
+- [I] Idea `- [I]`
+- [p] Pro `- [p]`
+- [c] Con `- [c]`
+- [b] Bookmark  `- [b]`
+- [u] Up `- [u]`
+- [d] Down `- [d]`
+- [r] Rule/Law  `- [r]`
+- [L] Language/Translation  `- [L]`
+- [t] Time/Clock `- [t]`
+- [T] Telephone `- [T]`
 
 ---
 
 # Tokyo Night
-['dark', 'light']
+
 Repo: https://github.com/tcmmichaelb139/obsidian-tokyonight
-Docs: 
-Code: 
+Docs: None (Appears to have used ones from Border theme)
+Code: https://github.com/tcmmichaelb139/obsidian-tokyonight/blob/ea79aba4359704497be7e40d15628636c81a9a0d/theme.css#L562
+
+- [ ] To Do `- [ ]`
+- [/] In Progress `- [/]`
+- [x] Done `- [x]`
+- [-] Cancelled `- [-]`
+- [>] Rescheduled `- [>]`
+- [<] Scheduling `- [<]`
+
+- [!] Important `- [!]`
+- [?] Question `- [?]`
+- [i] Information `- [i]`
+- [S] Amount `- [S]`
+- [*] Star `- [*]`
+- [b] Bookmark `- [b]`
+- ["] Quote `- ["]`
+- [l] Location `- [l]`
+- [I] Idea `- [I]`
+- [p] Pros `- [p]`
+- [c] Cons `- [c]`
+- [u] Up `- [u]`
+- [d] Down `- [d]`
+
+- [n] Note `- [n]`
 
 ---
 
@@ -384,10 +468,33 @@ Code:
 ---
 
 # Border
-['dark', 'light']
+
 Repo: https://github.com/Akifyss/obsidian-border
-Docs: 
-Code: 
+Docs: https://github.com/Akifyss/obsidian-border?tab=readme-ov-file#alternate-checkboxes
+Code: https://github.com/Akifyss/obsidian-border/blob/2771957ab92e6faddd7edad4e0cf65b7e8ef66bb/theme.css#L7844
+
+- [ ] To Do `- [ ]`
+- [/] In Progress `- [/]`
+- [x] Done `- [x]`
+- [-] Cancelled `- [-]`
+- [>] Rescheduled `- [>]`
+- [<] Scheduling `- [<]`
+
+- [!] Important `- [!]`
+- [?] Question `- [?]`
+- [i] Information `- [i]`
+- [S] Amount `- [S]`
+- [*] Star `- [*]`
+- [b] Bookmark `- [b]`
+- ["] Quote `- ["]`
+- [l] Location `- [l]`
+- [I] Idea `- [I]`
+- [p] Pros `- [p]`
+- [c] Cons `- [c]`
+- [u] Up `- [u]`
+- [d] Down `- [d]`
+
+- [n] Note `- [n]`
 
 ---
 
@@ -424,10 +531,37 @@ Code:
 ---
 
 # Cyber Glow
-['dark', 'light']
 Repo: https://github.com/ArtexJay/Obsidian-CyberGlow
-Docs: 
-Code: 
+Docs: https://github.com/ArtexJay/Obsidian-CyberGlow?tab=readme-ov-file#what-to-expect
+Code: https://github.com/ArtexJay/Obsidian-CyberGlow/blob/main/theme.css#L3436
+
+
+- [x] Checkmark `- [x]`
+- [?] Question `- [?]`
+- [-] Removed `- [-]`
+- [!] Important  `- [!]`
+- [>] Delayed `- [>]`
+- [/] Half-done/WIP  `- [/]`
+- [R] Review  `- [R]`
+- [+] Archived `- [+]`
+- [b] Bookmark  `- [b]`
+- [B] Brainstorm `- [B]`
+- [D] Planned `- [D]`
+- [i] Idea `- [i]`
+- [I] Info `- [I]`
+- [N] Note `- [N]`
+- [<] Scheduling `- [<]`
+- [P] Positive  `- [P]` or `- [p]`
+- [C] Negative  `- [C]` or `- [c]`
+- [Q] Quote `- [Q]` or `- ["]`
+- [S] Savings `- [S]`
+- [f] Fire `- [f]`
+- [k] Key `- [k]`
+- [w] Win `- [w]`
+- [u] Up `- [u]`
+- [d] Down `- [d]`
+- [l] Location `- [l]`
+- [*] Star `- [*]`
 
 ---
 

--- a/Themes - Alternative Checkboxes.md
+++ b/Themes - Alternative Checkboxes.md
@@ -574,18 +574,47 @@ Code:
 ---
 
 # Shiba Inu
-['dark', 'light']
+
 Repo: https://github.com/faroukx/Obsidian-shiba-inu-theme
-Docs: 
-Code: 
+Docs: https://github.com/faroukx/Obsidian-shiba-inu-theme?tab=readme-ov-file#personalized-checkboxes
+Code: https://github.com/faroukx/Obsidian-shiba-inu-theme/blob/main/theme.css (Only minified available)
+
+- [ ] Unchecked `- [ ]`
+- [x] Checked `- [x]`
+- [>] Rescheduled `- [>]`
+- [<] Scheduled `- [<]`
+- [!] Important `- [!]`
+- [-] Cancelled `- [-]`
+- [/] In Progress `- [/]`
+- [?] Question `- [?]`
+- [*] Star `- [*]`
+- [n] Note `- [n]`
+- [l] Location `- [l]`
+- [i] Information `- [i]`
+- [I] Idea `- [I]`
+- [S] Amount `- [S]`
+- [p] Pro `- [p]`
+- [c] Con `- [c]`
+- [b] Bookmark `- [b]`
+- [s] Study `- [s]`
+- [r] Reminder `- [r]`
 
 ---
 
-# PLN
-['dark', 'light']
+# PLN (Pipe Loves Nord)
+
 Repo: https://github.com/PipeItToDevNull/PLN
-Docs: 
-Code: 
+Docs: https://github.com/PipeItToDevNull/PLN?tab=readme-ov-file#custom-checkboxes
+Code: https://github.com/PipeItToDevNull/PLN/blob/master/snippets/checkboxes.css
+
+- [ ] Open `- [ ]`
+- [x] Complete `- [x]`
+- [!] Important `- [!]`
+- [>] Deferred `- [>]`
+- [?] Question `- [?]`
+- [i] Info `- [i]`
+- [-] Cancelled  `- [-]`
+- [/] Partial `- [/]`
 
 ---
 
@@ -614,10 +643,38 @@ Code:
 ---
 
 # Obsidianotion
-['dark', 'light']
+
 Repo: https://github.com/diegoeis/obsidianotion
-Docs: 
-Code: 
+Docs: https://github.com/diegoeis/obsidianotion?tab=readme-ov-file#checklists-styles
+Code: https://github.com/diegoeis/obsidianotion/blob/092b29b9aaece2d5a0975ffe4d6b4c75b62e44fd/theme.css#L1221
+
+Uses the same set as Things / Minimal themes.
+
+- [ ] Normal `- [ ]`
+- [/] Incomplete `- [/]`
+- [x] Done `- [x]`
+- [-] Cancelled `- [-]`
+- [>] Forwarded `- [>]`
+- [<] Scheduling `- [<]`
+
+- [?] Question `- [?]`
+- [!] Exclamation `- [!]`
+- [*] Star `- [*]`
+- ["] Quote `- ["]`
+- [l] Location `- [l]`
+- [b] Bookmark `- [b]`
+- [i] Information `- [i]`
+- [S] Savings `- [S]`
+- [I] Idea `- [I]`
+- [p] Thumbs Up `- [p]`
+- [c] Thumbs Down `- [c]`
+- [f] Fire `- [f]`
+- [k] Key `- [k]`
+- [w] Win `- [w]`
+- [u] Up `- [u]`
+- [d] Down `- [d]`
+
+- [s] Thread? / String?  `- [s]` (Specified incorrectly in Docs as Forwarded but available with no label in code)
 
 ---
 
@@ -646,18 +703,52 @@ Code:
 ---
 
 # Maple
-['dark', 'light']
+
 Repo: https://github.com/subframe7536/obsidian-theme-maple
-Docs: 
-Code: 
+Docs:
+Code: https://github.com/subframe7536/obsidian-theme-maple/blob/bb117504f9fe91e804442f175d9a94f67bb8dbf0/src/editor/checkbox.scss
+
+Uses code from Border theme.
+
+- [ ] To Do `- [ ]`
+- [/] In Progress `- [/]`
+- [x] Done `- [x]`
+- [-] Cancelled `- [-]`
+- [>] Rescheduled `- [>]`
+- [<] Scheduling `- [<]`
+
+- [!] Important `- [!]`
+- [?] Question `- [?]`
+- [i] Information `- [i]`
+- [S] Amount `- [S]`
+- [*] Star `- [*]`
+- [b] Bookmark `- [b]`
+- ["] Quote `- ["]`
+- [l] Location `- [l]`
+- [I] Idea `- [I]`
+- [p] Pros `- [p]`
+- [c] Cons `- [c]`
+- [u] Up `- [u]`
+- [d] Down `- [d]`
+
+- [n] Note `- [n]` 
 
 ---
 
-# Ebullientworks
-['dark', 'light']
+# EbullientWorks
 Repo: https://github.com/ebullient/obsidian-theme-ebullientworks
-Docs: 
-Code: 
+Docs: https://github.com/ebullient/obsidian-theme-ebullientworks?tab=readme-ov-file#alternative-checkboxes
+Code: https://github.com/ebullient/obsidian-theme-ebullientworks/blob/main/src/fragments/_06a-checkbox-mixin.scss
+
+- [ ] Unchecked `- [ ]`
+- [x] Checked `- [x]`
+- [-] Cancelled `- [-]`
+- [/] In Progress `- [/]`
+- [>] Deferred `- [>]`
+- [!] Important `- [!]`
+- [?] Question `- [?]`
+- [r] Review `- [r]` or `- [R]` (Capital R - Not mentioned in docs)
+- [b] Bookmark `- [b]` (Not mentioned in docs)
 
 ---
 
@@ -669,19 +760,60 @@ Code:
 
 ---
 
-# Pine Forest Berry
-['dark', 'light']
-Repo: https://github.com/Nilahn/pine_forest_berry
-Docs: 
-Code: 
+# Forest Pine Berry (Unmaintained?)
+Repo: https://github.com/Nilahn/pine_forest_berry/
+Docs: None (Appears to use Minimal snippet)
+Code: https://github.com/Nilahn/pine_forest_berry/blob/e74bd849e654c22b857229ef0f9c6c6834090d2a/obsidian.css#L999
+
+Doesn't install correctly since it only has `obsidian.css` and no `theme.css`.
+
+- [>] Forwarded `- [>]`
+- [<] Schedule `- [<]`
+- [?] Question `- [?]`
+- [/] Incomplete `- [/]`
+- [!] Important `- [!]`
+- ["] Quote `- ["]`
+- [-] Cancelled `- [-]`
+- [*] Star `- [*]`
+- [l] Location `- [l]`
+- [i] Info `- [i]`
+- [S] Amount / Savings / Money `- [S]`
+- [I] Idea / Light Bulb `- [I]`
+- [f] Fire `- [f]`
+- [k] Key `- [k]`
+- [u] Up `- [u]`
+- [d] Down `- [d]`
+- [w] Win  `- [w]`
+- [p] Pros `- [p]`
+- [c] Cons  `- [c]`
+- [b] Bookmark `- [b]`
 
 ---
 
 # Aura
-['dark', 'light']
+
 Repo: https://github.com/ashwinjadhav818/obsidian-aura
-Docs: 
-Code: 
+Docs: None (I guessed the uses based on other implementations)
+Code: https://github.com/ashwinjadhav818/obsidian-aura/blob/925571586651e756bf38632178cc4a387f5a6c98/src/features/checkbox.scss
+
+- [x] Check `- [x]`
+- [X] Alt Check? `- [X]`
+- [?] Question `- [?]`
+- [-] Cancelled? `- [-]`
+- [!] Important  `- [!]`
+- [>] Deffered?  `- [>]`
+- [/] Settings? `- [/]`
+- [R] Clock / Time `- [R]`
+- [+] Add? `- [+]`
+- [b] Bookmark `- [b]`
+- [B] Bolt?  `- [B]`
+- [D] Date / Callendar ? `- [D]`
+- [I] Information `- [I]`
+- [i] Idea / Light Bulb `- [i]`
+- [N] Note `- [N]`
+- [Q] Quote `- [Q]`
+- [P] Thumbs Up `- [P]`
+- [C] Thumbs Down `- [C]`
 
 ---
 
@@ -774,10 +906,75 @@ Code:
 ---
 
 # Vicious
-['light', 'dark']
+
 Repo: https://github.com/zaheralmajed/vicious-theme-obsidian
-Docs: 
-Code: 
+Docs: https://github.com/zaheralmajed/vicious-theme-obsidian?tab=readme-ov-file#enhanced-checkboxes
+Code: https://github.com/zaheralmajed/vicious-theme-obsidian/blob/686d487e0705fd6b7aced4451400512bba919f56/theme.css#L2547
+
+- [ ] Unchecked `- [ ]`
+- [x] Checked `- [x]`
+- [-] Cancelled `- [-]`
+- [)] Good `- [)]`
+- [:] Pin `- [:]`
+- [(] Bad `- [(]`
+- [}] High `- [}]`
+- [=] Normal `- [=]`
+- [{] Low `- [{]`
+- [?] Question `- [?]`
+- [*] Star `- [*]`
+- [!] Important `- [!]`
+- [>] Forward `- [>]`
+- [<] Backward `- [<]`
+- [/] Pause `- [/]`
+- [+] Upward `- [+]`
+- [_] Downward `- [_]`
+- [%] Recurring `- [%]`
+- [&] Trash `- [&]`
+- [.] Lock `- [.]`
+- [@] At `- [@]`
+- [#] Hashtag `- [#]`
+- ['] Quote `- [']`
+- [a] Archive `- [a]`
+- [A] Alarm  `- [A]`
+- [b] Bookmark `- [b]`
+- [B] Birthday `- [B]`
+- [c] Comment `- [c]`
+- [C] Clip `- [C]`
+- [d] Diamond `- [d]`
+- [D] Document `- [D]`
+- [e] Envelope `- [e]`
+- [E] Eye `- [E]`
+- [f] Flame `- [f]`
+- [F] Financial `- [F]`
+- [g] Gaming `- [g]`
+- [G] GYM `- [G]`
+- [h] Home `- [h]`
+- [H] Heart `- [H]`
+- [i] Info `- [i]`
+- [I] Idea `- [I]`
+- [m] Music `- [m]`
+- [M] Medical `- [M]`
+- [p] Person `- [p]`
+- [P] Plane `- [P]`
+- [s] Sport `- [s]`
+- [S] Search `- [S]`
+- [u] URL `- [u]`
+- [v] Video `- [v]`
+- [w] World `- [w]`
+- [W] Work `- [W]`
+- [z] Moon `- [z]`
+- [Z] Sun `- [Z]`
+- [0] Text Highlight 0 `- [0]`
+- [1] Text Highlight 1 `- [1]`
+- [2] Text Highlight 2 `- [2]`
+- [3] Text Highlight 3 `- [3]`
+- [4] Text Highlight 4 `- [4]`
+- [5] Text Highlight 5 `- [5]`
+- [6] Text Highlight 6 `- [6]`
+- [7] Text Highlight 7 `- [7]`
+- [8] Text Highlight 8 `- [8]`
+- [9] Text Highlight 9 `- [9]`
+- [§] Text Highlight § `- [§]`
 
 ---
 
@@ -790,12 +987,34 @@ Code:
 ---
 
 # Elegance
-['dark', 'light']
-Repo: https://github.com/Victologo/elegance-theme
-Docs: 
-Code: 
 
----
+Repo: https://github.com/Victologo/elegance-theme
+Docs: https://github.com/Victologo/elegance-theme?tab=readme-ov-file#checboxes-minimal-theme-by-kepano
+Code: https://github.com/Victologo/elegance-theme/blob/83947941e3f44fb4f37df291c8cff08f299cc2fc/theme.css#L3644
+
+- [ ] To-Do `- [ ]`
+- [/] Incomplete `- [/]` (Not mentioned in Docs)
+- [x] Done `- [x]`
+- [-] Cancelled `- [-]`
+- [>] Forwarded `- [>]`
+- [<] Scheduling `- [<]`
+
+- [?] Question `- [?]`
+- [!] Important `- [!]`
+- [*] Star `- [*]`
+- ["] Quote `- ["]`
+- [l] Location `- [l]`
+- [b] Bookmark `- [b]`
+- [i] Information `- [i]`
+- [S] Savings `- [S]`
+- [I] Idea `- [I]`
+- [p] Pros `- [p]`
+- [c] Cons `- [c]`
+- [f] Fire `- [f]`
+- [k] Key `- [k]`
+- [w] Win `- [w]`
+- [u] Up `- [u]`
+- [d] Down `- [d]`
 
 # Aurora
 ['dark']


### PR DESCRIPTION
### Background

As discussed in [Discord](https://discord.com/channels/686053708261228577/1291469509336502272/1291870012470071317), though it took longer than I expected!

### Content

I retained the original order, even where it differed from the downloads count, and retained all original content.

And added all themes in from this revision:
https://github.com/obsidianmd/obsidian-releases/blob/a905a5811bd3c707fe3826ca5fc95c744f809692/community-css-themes.json

### Labelling dark/light mode

As a temporary addition, I have included the light/dark modes supported, to show which ones were dark-only, and a few which are dark+light, but their URLs were not exactly contained in the list of 'Themes without Alternative Checkboxes' callout at the top of the file.

For example:

```
# Terminal
['dark']
Repo: https://github.com/zcysxy/Obsidian-Terminal-Theme
```

I'm presuming you will delete all those dark/light lines when you don't need them - the info seemed usedful.

### Merging

If you merge, I suggest you squash the changes... I committed it in stages for safety, having broken it half-way through a long manual process.

### Showing my working

The code was a terrible hack of the Obsidian hub code. I'll upload code here, below, in case it is used again.

